### PR TITLE
Add v1.2 endpoint tests

### DIFF
--- a/src/simdb/remote/models.py
+++ b/src/simdb/remote/models.py
@@ -2,7 +2,18 @@
 
 from datetime import datetime as dt
 from datetime import timezone
-from typing import Annotated, Any, Generic, List, Literal, Optional, TypeVar, Union
+from pathlib import Path
+from typing import (
+    Annotated,
+    Any,
+    Dict,
+    Generic,
+    List,
+    Literal,
+    Optional,
+    TypeVar,
+    Union,
+)
 from urllib.parse import urlencode
 from uuid import UUID, uuid1
 
@@ -14,6 +25,8 @@ from pydantic import (
     RootModel,
     model_validator,
 )
+
+from simdb.cli.manifest import DataObject
 
 HexUUID = Annotated[UUID, PlainSerializer(lambda x: x.hex, return_type=str)]
 """UUID serialized as a hex string."""
@@ -302,3 +315,145 @@ class SimulationTraceData(SimulationData):
     """Simulation this one replaces."""
     replaces_reason: Optional[Any] = None
     """Reason for replacement."""
+
+
+class ChunkInfo(BaseModel):
+    """Information about a single chunk in a chunked file upload."""
+
+    chunk_size: int
+    """Length of the chunk."""
+    chunk: int
+    """Index of the chunk."""
+    num_chunks: Optional[int] = 1
+    """Total amount of chunks in the file."""
+
+
+class ChunkInfoDict(RootModel):
+    """Dictionary mapping file UUID hex to chunk info."""
+
+    root: Dict[str, ChunkInfo]
+
+
+class FileUploadData(BaseModel):
+    """Data payload for file chunk upload (sent as JSON in 'data' field)."""
+
+    simulation: SimulationData
+    """The simulation the file belongs to."""
+    file_type: str
+    """Type of the file."""
+    chunk_info: Optional[Dict[str, ChunkInfo]] = None
+    """Info about the chunk."""
+
+
+class FilesGetResponse(RootModel):
+    root: List[FileData]
+
+
+class FileInfo(BaseModel):
+    path: Path
+    checksum: str
+
+
+class FileGetDataResponse(FileData):
+    files: List[FileInfo]
+
+
+class FileUploadResponse(BaseModel):
+    """Response from file upload/chunk upload endpoint."""
+
+    # The endpoint returns empty {} on success
+    pass
+
+
+class FileRegistrationItem(BaseModel):
+    """A single file entry in the file registration payload."""
+
+    chunks: int
+    """The amount of chunks to be processed."""
+    file_type: str
+    """The file type."""
+    file_uuid: HexUUID
+    """The UUID of the file."""
+    ids_list: Optional[List[Any]] = None
+
+
+class FileRegistrationData(BaseModel):
+    """Payload for final file registration after chunk uploads."""
+
+    simulation: SimulationData
+    obj_type: DataObject.Type
+    files: List[FileRegistrationItem]
+
+
+class FileRegistrationResponse(BaseModel):
+    """Response from file registration endpoint."""
+
+    # The endpoint returns empty {} on success
+    pass
+
+
+class WatcherReference(BaseModel):
+    """An watcher entry reference."""
+
+    simulation: HexUUID
+    """Simulation UUID the watcher has been added to."""
+    watcher: str
+    """Username of the added watcher."""
+
+
+class WatcherPostResponse(BaseModel):
+    """Response from the add watcher endpoint."""
+
+    added: WatcherReference
+    """The added watcher data."""
+
+
+class WatcherPostRequest(BaseModel):
+    """Payload for adding a watcher to a simulation."""
+
+    user: Optional[str]
+    """Username of the watcher, defaults to the signed in user."""
+    email: Optional[str]
+    """Email of the watcher, defaults to the signed in user."""
+    notification: Literal["VALIDATION", "REVISION", "OBSOLESCENCE", "ALL"]
+    """Notificaiton type of the watcher."""
+
+
+class WatcherData(BaseModel):
+    """Payload describing a watcher."""
+
+    username: str
+    """Username of the watcher."""
+    email: str
+    """Email address of the watcher."""
+    notification: Literal["V", "R", "O", "A"]
+    """Notification type of the watcher.
+        Types are: V(alidation), R(evision), O(bsolescence) and A(ll)
+    """
+
+
+class WatcherGetResponse(RootModel):
+    """Response from the get watchers endpoint."""
+
+    root: List[WatcherData]
+
+
+class WatcherDeleteRequest(BaseModel):
+    """Payload for deleting a watcher from a simulation."""
+
+    user: str
+    """Username to delete from the watchers."""
+
+
+class WatcherDeleteResponse(BaseModel):
+    """Response from the delete watchers endpoint."""
+
+    removed: WatcherReference
+    """Reference to the deleted wacher."""
+
+
+class StagingDirectoryResponse(BaseModel):
+    """Response from the get staging dir endpoint."""
+
+    staging_dir: Path
+    """Path to the staging dir."""

--- a/src/simdb/remote/models.py
+++ b/src/simdb/remote/models.py
@@ -346,22 +346,31 @@ class FileUploadData(BaseModel):
 
 
 class FilesGetResponse(RootModel):
+    """Response from the get files endpoint."""
+
     root: List[FileData]
+    """List of files."""
 
 
 class FileInfo(BaseModel):
+    """Information about a single file on disk."""
+
     path: Path
+    """Path to the file."""
     checksum: str
+    """Checksum of the file."""
 
 
 class FileGetDataResponse(FileData):
+    """Response from the get file data endpoint, extending FileData with disk info."""
+
     files: List[FileInfo]
+    """List of file info entries for the files on disk."""
 
 
 class FileUploadResponse(BaseModel):
     """Response from file upload/chunk upload endpoint."""
 
-    # The endpoint returns empty {} on success
     pass
 
 
@@ -375,20 +384,23 @@ class FileRegistrationItem(BaseModel):
     file_uuid: HexUUID
     """The UUID of the file."""
     ids_list: Optional[List[Any]] = None
+    """List of IDS names associated with the file."""
 
 
 class FileRegistrationData(BaseModel):
     """Payload for final file registration after chunk uploads."""
 
     simulation: SimulationData
+    """The simulation the files belong to."""
     obj_type: DataObject.Type
+    """The type of the data object being registered."""
     files: List[FileRegistrationItem]
+    """List of file registration items."""
 
 
 class FileRegistrationResponse(BaseModel):
     """Response from file registration endpoint."""
 
-    # The endpoint returns empty {} on success
     pass
 
 

--- a/tests/remote/api/conftest.py
+++ b/tests/remote/api/conftest.py
@@ -1,0 +1,128 @@
+import base64
+import importlib
+import os
+import shutil
+import tempfile
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from simdb.cli.manifest import Manifest
+from simdb.config import Config
+from simdb.database.models import Simulation
+from simdb.remote.app import create_app
+from simdb.remote.models import (
+    FileData,
+    SimulationData,
+    SimulationPostData,
+)
+
+has_flask = importlib.util.find_spec("flask") is not None
+
+
+TEST_PASSWORD = "test123"
+CREDENTIALS = base64.b64encode(f"admin:{TEST_PASSWORD}".encode()).decode()
+HEADERS = {"Authorization": f"Basic {CREDENTIALS}"}
+
+SIMULATIONS = []
+for _ in range(100):
+    SIMULATIONS.append(Simulation(Manifest()))
+
+
+@pytest.fixture(scope="session")
+def client():
+    if not has_flask:
+        pytest.skip("Flask not installed")
+    config = Config()
+    config.load()
+    db_fd, db_file = tempfile.mkstemp()
+    upload_dir = tempfile.mkdtemp()
+    config.set_option("database.type", "sqlite")
+    config.set_option("database.file", db_file)
+    config.set_option("server.admin_password", TEST_PASSWORD)
+    config.set_option("server.upload_folder", upload_dir)
+    config.set_option("authentication.type", "None")
+    config.set_option("server.copy_files", False)
+    config.set_option("role.admin.users", "admin,admin2")
+    app = create_app(config=config, testing=True, debug=True)
+    app.testing = True
+
+    with app.test_client() as client:
+        # with app.app_context():
+        for sim in SIMULATIONS:
+            app.db.insert_simulation(sim)
+
+        app.db.session.commit()
+        app.db.session.close()
+
+        yield client
+
+    os.close(db_fd)
+    Path(app.simdb_config.get_option("database.file")).unlink()
+    shutil.rmtree(upload_dir)
+
+
+@pytest.fixture(scope="session")
+def client_copy_files():
+    if not has_flask:
+        pytest.skip("Flask not installed")
+    config = Config()
+    config.load()
+    db_fd, db_file = tempfile.mkstemp()
+    upload_dir = tempfile.mkdtemp()
+    config.set_option("database.type", "sqlite")
+    config.set_option("database.file", db_file)
+    config.set_option("server.admin_password", TEST_PASSWORD)
+    config.set_option("server.upload_folder", upload_dir)
+    config.set_option("authentication.type", "None")
+    config.set_option("server.copy_files", True)
+    config.set_option("role.admin.users", "admin,admin2")
+    app = create_app(config=config, testing=True, debug=True)
+    app.testing = True
+
+    with app.test_client() as client:
+        # with app.app_context():
+        for sim in SIMULATIONS:
+            app.db.insert_simulation(sim)
+
+        app.db.session.commit()
+        app.db.session.close()
+
+        yield client
+
+    os.close(db_fd)
+    Path(app.simdb_config.get_option("database.file")).unlink()
+    shutil.rmtree(upload_dir)
+
+
+def generate_simulation_data(
+    add_watcher=False, uploaded_by=None, alias=None, **overrides
+) -> SimulationPostData:
+    if alias is None:
+        alias = uuid.uuid4().hex
+    simulation_data = SimulationData(alias=alias, **overrides)
+    data = SimulationPostData(
+        simulation=simulation_data, add_watcher=add_watcher, uploaded_by=uploaded_by
+    )
+    return data
+
+
+def generate_simulation_file() -> FileData:
+    return FileData(
+        type="FILE",
+        uri="file:///path/to/file",
+        checksum="fake_checksum",
+        datetime=datetime.now(timezone.utc),
+    )
+
+
+def post_simulation(client, simulation_data, headers=HEADERS):
+    rv_post = client.post(
+        "/v1.2/simulations",
+        json=simulation_data.model_dump(mode="json"),
+        headers=headers,
+        content_type="application/json",
+    )
+    return rv_post

--- a/tests/remote/api/conftest.py
+++ b/tests/remote/api/conftest.py
@@ -65,8 +65,9 @@ def client():
 
 
 @pytest.fixture(scope="session")
-@pytest.mark.skipif(not has_flask, "Flask not installed")
 def client_copy_files():
+    if not has_flask:
+        pytest.skip("Flask not installed")
     config = Config()
     config.load()
     db_fd, db_file = tempfile.mkstemp()

--- a/tests/remote/api/conftest.py
+++ b/tests/remote/api/conftest.py
@@ -65,9 +65,8 @@ def client():
 
 
 @pytest.fixture(scope="session")
+@pytest.mark.skipif(not has_flask, "Flask not installed")
 def client_copy_files():
-    if not has_flask:
-        pytest.skip("Flask not installed")
     config = Config()
     config.load()
     db_fd, db_file = tempfile.mkstemp()

--- a/tests/remote/api/test_files.py
+++ b/tests/remote/api/test_files.py
@@ -1,0 +1,190 @@
+import gzip
+import hashlib
+import io
+import json
+import tarfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from conftest import (
+    HEADERS,
+    generate_simulation_data,
+    post_simulation,
+)
+
+from simdb.cli.manifest import DataObject
+from simdb.json import CustomEncoder
+from simdb.remote.models import (
+    ChunkInfo,
+    FileData,
+    FileGetDataResponse,
+    FileRegistrationData,
+    FileRegistrationItem,
+    FilesGetResponse,
+    FileUploadData,
+    SimulationPostData,
+)
+
+
+def create_simulation_with_file(
+    client, alias, file_content=b"Test file content for upload"
+) -> SimulationPostData:
+    chunk_size = 1024
+    chunks = [
+        file_content[i : i + chunk_size]
+        for i in range(0, len(file_content), chunk_size)
+    ]
+    num_chunks = len(chunks)
+    test_checksum = hashlib.sha1(file_content).hexdigest()
+
+    simulation_data = generate_simulation_data(
+        alias=alias,
+        inputs=[
+            FileData(
+                type="FILE",
+                uri="file:///tmp/test_file.txt",
+                checksum=test_checksum,
+                datetime=datetime.now(timezone.utc),
+            )
+        ],
+    )
+
+    rv_sim = post_simulation(client, simulation_data)
+    assert rv_sim.status_code == 200, rv_sim.data
+
+    # Get the actual file UUID from the simulation (auto-generated)
+    file_uuid = simulation_data.simulation.inputs[0].uuid
+    for i, chunk in enumerate(chunks):
+        buf = io.BytesIO()
+        with gzip.GzipFile(fileobj=buf, mode="wb") as gz_file:
+            gz_file.write(chunk)
+        compressed_content = buf.getvalue()
+
+        upload_data = FileUploadData(
+            simulation=simulation_data.simulation,
+            file_type="input",
+            chunk_info={
+                file_uuid.hex: ChunkInfo(
+                    chunk_size=chunk_size, chunk=i, num_chunks=num_chunks
+                )
+            },
+        )
+
+        _rv_chunk = client.post(
+            "/v1.2/files",
+            data={
+                "data": (
+                    io.BytesIO(
+                        json.dumps(
+                            upload_data.model_dump(mode="json"), cls=CustomEncoder
+                        ).encode()
+                    ),
+                    "data",
+                    "text/json",
+                ),
+                "files": (
+                    io.BytesIO(compressed_content),
+                    file_uuid.hex,
+                    "application/octet-stream",
+                ),
+            },
+            headers=HEADERS,
+        )
+
+        # The chunk upload should succeed
+        assert _rv_chunk.status_code == 200, _rv_chunk.data
+
+    registration_data = FileRegistrationData(
+        simulation=simulation_data.simulation,
+        obj_type=DataObject.Type.FILE,
+        files=[
+            FileRegistrationItem(
+                chunks=num_chunks,
+                file_type="input",
+                file_uuid=file_uuid,
+                ids_list=None,
+            )
+        ],
+    )
+
+    rv_register = client.post(
+        "/v1.2/files",
+        json=registration_data.model_dump(mode="json"),
+        headers=HEADERS,
+        content_type="application/json",
+    )
+    assert rv_register.status_code == 200, rv_register.data
+
+    return simulation_data
+
+
+def test_post_files_endpoint_with_file(client):
+    """Test POST /v1.2/files endpoint with single chunk."""
+    create_simulation_with_file(client, "test-upload-file")
+
+
+def test_post_files_endpoint_chunked_upload(client):
+    """Test POST /v1.2/files endpoint with multiple chunks."""
+    create_simulation_with_file(
+        client, "test-upload-file-chunked", file_content=b"Test upload" * 1000
+    )
+
+
+def test_simulation_package_endpoint(client):
+    """Test GET /v1.2/simulation/package/{simulation_id} endpoint."""
+    test_content = b"test content"
+    simulation_data = create_simulation_with_file(
+        client, "test-simulation-package", file_content=test_content
+    )
+
+    # Test package endpoint
+    rv = client.get(
+        f"/v1.2/simulation/package/{simulation_data.simulation.uuid.hex}",
+        headers=HEADERS,
+    )
+
+    assert rv.status_code == 200
+
+    tar_data = io.BytesIO(rv.data)
+    with tarfile.open(mode="r:gz", fileobj=tar_data) as tar:
+        for member in tar.getmembers():
+            if member.isfile():
+                assert Path(member.name).name == "test_file.txt"
+                data = tar.extractfile(member)
+                assert data.read() == test_content
+
+
+def test_get_files_list(client):
+    simulation_data = create_simulation_with_file(client, "test-get-file")
+
+    rv = client.get("/v1.2/files", headers=HEADERS)
+    assert rv.status_code == 200
+
+    data = FilesGetResponse.model_validate(rv.json)
+    file_uuid = simulation_data.simulation.inputs[0].uuid
+    assert any(file_uuid == f.uuid for f in data.root)
+
+
+def test_get_file_by_uuid(client):
+    simulation_data = create_simulation_with_file(client, "test-get-file-by-uuid")
+
+    file_uuid = simulation_data.simulation.inputs[0].uuid
+    rv = client.get(f"/v1.2/file/{file_uuid.hex}", headers=HEADERS)
+    assert rv.status_code == 200
+
+    FileGetDataResponse.model_validate(rv.json)
+
+
+@pytest.mark.xfail(reason="File path is not stored correctly?")
+def test_download_file(client):
+    file_content = b"test data"
+    simulation_data = create_simulation_with_file(
+        client, "test-get-file-by-uuid", file_content=file_content
+    )
+
+    file_uuid = simulation_data.simulation.inputs[0].uuid
+    rv = client.get(f"/v1.2/file/download/{file_uuid.hex}", headers=HEADERS)
+    assert rv.status_code == 200
+
+    assert rv.data == file_content

--- a/tests/remote/api/test_metadata.py
+++ b/tests/remote/api/test_metadata.py
@@ -1,0 +1,59 @@
+from conftest import (
+    HEADERS,
+    generate_simulation_data,
+    post_simulation,
+)
+
+
+def test_get_metadata_keys(client):
+    """Test GET /v1.2/metadata endpoint - list all metadata keys."""
+    # Create some simulations with metadata first
+    simulation_data_1 = generate_simulation_data(
+        metadata={"machine": "test-machine-1", "code": "test-code"}
+    )
+    rv_post_1 = post_simulation(client, simulation_data_1)
+    assert rv_post_1.status_code == 200
+
+    simulation_data_2 = generate_simulation_data(
+        metadata={"machine": "test-machine-2", "code": "test-code"}
+    )
+    rv_post_2 = post_simulation(client, simulation_data_2)
+    assert rv_post_2.status_code == 200
+
+    # Get all metadata keys
+    rv = client.get("/v1.2/metadata", headers=HEADERS)
+
+    assert rv.status_code == 200
+    # The response should be a list of metadata keys
+    assert isinstance(rv.json, list)
+
+
+def test_get_metadata_values(client):
+    """Test GET /v1.2/metadata/{name} endpoint - list all values for a metadata key."""
+    # Create some simulations with metadata first
+    simulation_data_1 = generate_simulation_data(metadata={"machine": "machine-a"})
+    rv_post_1 = post_simulation(client, simulation_data_1)
+    assert rv_post_1.status_code == 200
+
+    simulation_data_2 = generate_simulation_data(metadata={"machine": "machine-b"})
+    rv_post_2 = post_simulation(client, simulation_data_2)
+    assert rv_post_2.status_code == 200
+
+    # Get values for the "machine" metadata key
+    rv = client.get("/v1.2/metadata/machine", headers=HEADERS)
+
+    assert rv.status_code == 200
+    # The response should be a list of values
+    assert isinstance(rv.json, list)
+    # Should contain both machine values
+    assert "machine-a" in rv.json or "machine-b" in rv.json
+
+
+def test_get_metadata_values_nonexistent_key(client):
+    """Test GET /v1.2/metadata/{name} endpoint - non-existent key."""
+    # Get values for a metadata key that doesn't exist
+    rv = client.get("/v1.2/metadata/nonexistent-key", headers=HEADERS)
+
+    assert rv.status_code == 200
+    # Should return an empty list or list without the key
+    assert isinstance(rv.json, list)

--- a/tests/remote/api/test_simulations.py
+++ b/tests/remote/api/test_simulations.py
@@ -1,23 +1,14 @@
-import base64
-import contextlib
-import importlib
-import os
-import shutil
-import tempfile
 import uuid
-from datetime import datetime, timezone
-from pathlib import Path
 
 import pytest
+from conftest import (
+    HEADERS,
+    generate_simulation_data,
+    generate_simulation_file,
+    post_simulation,
+)
 
-from simdb.cli.manifest import Manifest
-from simdb.config import Config
-from simdb.database.models import Simulation
-
-with contextlib.suppress(ModuleNotFoundError):
-    from simdb.remote.app import create_app
 from simdb.remote.models import (
-    FileData,
     MetadataData,
     MetadataDataList,
     MetadataDeleteData,
@@ -26,86 +17,10 @@ from simdb.remote.models import (
     SimulationData,
     SimulationDataResponse,
     SimulationListItem,
-    SimulationPostData,
     SimulationPostResponse,
     SimulationTraceData,
     StatusPatchData,
 )
-
-has_flask = importlib.util.find_spec("flask") is not None
-
-
-TEST_PASSWORD = "test123"
-CREDENTIALS = base64.b64encode(f"admin:{TEST_PASSWORD}".encode()).decode()
-HEADERS = {"Authorization": f"Basic {CREDENTIALS}"}
-
-SIMULATIONS = []
-for _ in range(100):
-    SIMULATIONS.append(Simulation(Manifest()))
-
-
-@pytest.fixture(scope="session")
-def client():
-    if not has_flask:
-        pytest.skip("Flask not installed")
-    config = Config()
-    config.load()
-    db_fd, db_file = tempfile.mkstemp()
-    upload_dir = tempfile.mkdtemp()
-    config.set_option("database.type", "sqlite")
-    config.set_option("database.file", db_file)
-    config.set_option("server.admin_password", TEST_PASSWORD)
-    config.set_option("server.upload_folder", upload_dir)
-    config.set_option("authentication.type", "None")
-    config.set_option("server.copy_files", False)
-    config.set_option("role.admin.users", "admin,admin2")
-    app = create_app(config=config, testing=True, debug=True)
-    app.testing = True
-
-    with app.test_client() as client:
-        # with app.app_context():
-        for sim in SIMULATIONS:
-            app.db.insert_simulation(sim)
-
-        app.db.session.commit()
-        app.db.session.close()
-
-        yield client
-
-    os.close(db_fd)
-    Path(app.simdb_config.get_option("database.file")).unlink()
-    shutil.rmtree(upload_dir)
-
-
-def generate_simulation_data(
-    add_watcher=False, uploaded_by=None, alias=None, **overrides
-) -> SimulationPostData:
-    if alias is None:
-        alias = uuid.uuid4().hex
-    simulation_data = SimulationData(alias=alias, **overrides)
-    data = SimulationPostData(
-        simulation=simulation_data, add_watcher=add_watcher, uploaded_by=uploaded_by
-    )
-    return data
-
-
-def generate_simulation_file() -> FileData:
-    return FileData(
-        type="FILE",
-        uri="file:///path/to/file",
-        checksum="fake_checksum",
-        datetime=datetime.now(timezone.utc),
-    )
-
-
-def post_simulation(client, simulation_data, headers=HEADERS):
-    rv_post = client.post(
-        "/v1.2/simulations",
-        json=simulation_data.model_dump(mode="json"),
-        headers=headers,
-        content_type="application/json",
-    )
-    return rv_post
 
 
 def test_get_root(client):

--- a/tests/remote/api/test_staging.py
+++ b/tests/remote/api/test_staging.py
@@ -1,0 +1,54 @@
+import hashlib
+import uuid
+from datetime import datetime, timezone
+
+from conftest import HEADERS, generate_simulation_data, post_simulation
+
+from simdb.remote.models import FileData, StagingDirectoryResponse
+
+
+def test_get_staging_dir(client):
+    """Test GET /v1.2/staging_dir endpoint - get base staging directory."""
+    rv = client.get("/v1.2/staging_dir", headers=HEADERS)
+
+    assert rv.status_code == 200
+    StagingDirectoryResponse.model_validate(rv.json)
+
+
+def test_get_staging_dir_for_simulation_with_uuid(client):
+    """Test GET /v1.2/staging_dir/{sim_hex} endpoint with valid UUID hex."""
+    valid_uuid = uuid.uuid4().hex
+
+    rv = client.get(f"/v1.2/staging_dir/{valid_uuid}", headers=HEADERS)
+
+    assert rv.status_code == 200
+    StagingDirectoryResponse.model_validate(rv.json)
+
+
+def test_create_simulation_from_staging_dir(client_copy_files):
+    file_data = b"test_data"
+    checksum = hashlib.sha1(file_data).hexdigest()
+    simulation_data = generate_simulation_data(
+        alias="test-simulation",
+        inputs=[
+            FileData(
+                type="FILE",
+                uri="file:///path/to/file",
+                checksum=checksum,
+                datetime=datetime.now(timezone.utc),
+            )
+        ],
+    )
+
+    rv = client_copy_files.get(
+        f"/v1.2/staging_dir/{simulation_data.simulation.uuid.hex}", headers=HEADERS
+    )
+
+    assert rv.status_code == 200
+    staging_data = StagingDirectoryResponse.model_validate(rv.json)
+
+    # Store the file in the staging area
+    (staging_data.staging_dir / "file").write_bytes(file_data)
+
+    rv = post_simulation(client_copy_files, simulation_data)
+    assert rv.status_code == 200, rv.data

--- a/tests/remote/api/test_watchers.py
+++ b/tests/remote/api/test_watchers.py
@@ -1,0 +1,85 @@
+from conftest import (
+    HEADERS,
+    generate_simulation_data,
+    post_simulation,
+)
+
+from simdb.remote.models import (
+    WatcherDeleteRequest,
+    WatcherDeleteResponse,
+    WatcherGetResponse,
+    WatcherPostRequest,
+    WatcherPostResponse,
+)
+
+
+def test_get_watchers(client):
+    """Test GET /v1.2/watchers/{simulation_id} endpoint."""
+    # Create a simulation first
+    simulation_data = generate_simulation_data()
+    rv_post = post_simulation(client, simulation_data)
+    assert rv_post.status_code == 200
+
+    # Get watchers for the simulation
+    rv = client.get(
+        f"/v1.2/watchers/{simulation_data.simulation.uuid.hex}", headers=HEADERS
+    )
+
+    assert rv.status_code == 200
+    WatcherGetResponse.model_validate(rv.json)
+
+
+def test_post_watchers(client):
+    """Test POST /v1.2/watchers/{simulation_id} endpoint - add watcher."""
+    # Create a simulation first
+    simulation_data = generate_simulation_data()
+    rv_post = post_simulation(client, simulation_data)
+    assert rv_post.status_code == 200
+
+    post_data = WatcherPostRequest(
+        user="testuser", email="example@iter.org", notification="ALL"
+    )
+    # Add a watcher to the simulation
+    rv = client.post(
+        f"/v1.2/watchers/{simulation_data.simulation.uuid.hex}",
+        json=post_data.model_dump(mode="json"),
+        headers=HEADERS,
+        content_type="application/json",
+    )
+
+    assert rv.status_code == 200
+    data = WatcherPostResponse.model_validate(rv.json)
+    assert data.added.simulation == simulation_data.simulation.uuid
+
+
+def test_delete_watchers(client):
+    """Test DELETE /v1.2/watchers/{simulation_id} endpoint - remove watcher."""
+    # Create a simulation first
+    simulation_data = generate_simulation_data()
+    rv_post = post_simulation(client, simulation_data)
+    assert rv_post.status_code == 200
+
+    post_data = WatcherPostRequest(
+        user="testuser", email="example@iter.org", notification="ALL"
+    )
+    # Add a watcher first
+    rv_add = client.post(
+        f"/v1.2/watchers/{simulation_data.simulation.uuid.hex}",
+        json=post_data.model_dump(mode="json"),
+        headers=HEADERS,
+        content_type="application/json",
+    )
+    assert rv_add.status_code == 200
+
+    post_data = WatcherDeleteRequest(user="testuser")
+    # Remove the watcher
+    rv = client.delete(
+        f"/v1.2/watchers/{simulation_data.simulation.uuid.hex}",
+        json=post_data.model_dump(mode="json"),
+        headers=HEADERS,
+        content_type="application/json",
+    )
+
+    assert rv.status_code == 200
+    data = WatcherDeleteResponse.model_validate(rv.json)
+    assert data.removed.simulation == simulation_data.simulation.uuid


### PR DESCRIPTION
This extends #40 with tests for the `/files` `/metadata` and `/watcher` endpoints. I also organized the tests into separate files.