### PR TITLE
fix: make authentication ad_cert optional

### DIFF
--- a/docs/maintenance_guide.md
+++ b/docs/maintenance_guide.md
@@ -113,7 +113,7 @@ Options for the server configuration are:
 |----------------|-----------|----------|---------------------------------------------------------------|
 | authentication | ad_server | yes      | Active directory server used for user authentication.         |
 | authentication | ad_domain | yes      | Active directory domain used for user authentication.         |
-| authentication | ad_cert   | yes      | Path to the root ca certificate used for user authentication. |
+| authentication | ad_cert   | no       | Path to the root ca certificate used for user authentication. |
 
 ### LDAP authentication options
 

--- a/src/simdb/remote/core/auth/active_directory.py
+++ b/src/simdb/remote/core/auth/active_directory.py
@@ -26,7 +26,9 @@ class ActiveDirectoryAuthenticator(Authenticator):
             ad_config = {
                 "AD_SERVER": config.get_option("authentication.ad_server"),
                 "AD_DOMAIN": config.get_option("authentication.ad_domain"),
-                "AD_CA_CERT_FILE": config.get_option("authentication.ad_cert"),
+                "AD_CA_CERT_FILE": config.get_option(
+                    "authentication.ad_cert", default=""
+                ),
             }
             ad = EasyAD(ad_config)
         except (KeyError, ImportError):


### PR DESCRIPTION
The PR helps to make the ad_cert option of ActiveDirectory authentication optional