### PR TITLE
Add developer docs for ruff, ty and alembic

### DIFF
--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -1,33 +1,31 @@
 # Developer Guide
 
-## Setting up devloper environment
+## Setting up developer environment
 
 Checking out develop branch of SimDB:
 
 ```bash
 git clone https://github.com/iterorganization/SimDB.git
-cd simdb
+cd SimDB
 git checkout develop
 ```
 
-Create a virtual environment:
+Create a virtual environment and install SimDB with all development dependencies
+using the `dev` dependency group defined in `pyproject.toml`:
 
 ```bash
-python3 -m venv venv
-source venv/bin/activate
+pip install -e --group dev .
 ```
 
-Installing editable version of SimDB:
+You could also use uv to install all dependencies:
 
 ```bash
-pip install -e .
+uv sync
 ```
 
-Installing server dependencies:
 
-```bash
-pip install -e .[all]
-```
+This installs SimDB along with all tools needed for testing, linting, type
+checking, and running the server.
 
 ## Running the tests
 
@@ -43,42 +41,183 @@ pytest
 simdb_server
 ```
 
-This will start a server on port 5000. You can test this server is running by opening htpp://localhost:5000 in a browser.
+This will start a server on port 5000. You can test this server is running by opening http://localhost:5000 in a browser.
+
+## Linting and formatting
+
+SimDB uses [Ruff](https://docs.astral.sh/ruff/) for both linting and code
+formatting. Ruff replaces the previously used tools `flake8`, `pylint`, and
+`black`. The Ruff configuration is defined in `pyproject.toml` under
+`[tool.ruff]` and `[tool.ruff.lint]`.
+
+To check formatting:
+
+```bash
+python -m ruff format --check
+```
+
+To auto-fix formatting:
+
+```bash
+python -m ruff format
+```
+
+To check linting:
+
+```bash
+python -m ruff check
+```
+
+To auto-fix linting issues where possible:
+
+```bash
+python -m ruff check --fix
+```
+
+## Type checking
+
+SimDB uses [Ty](https://github.com/astral-sh/ty) for static type checking.
+
+To run type checking:
+
+```bash
+python -m ty check src
+```
+
+## Continuous integration
+
+The CI pipeline (defined in `.github/workflows/build_and_test.yml`) runs
+automatically on every push and pull request. It tests against Python 3.11,
+3.12, and 3.13, and runs the following checks in order:
+
+1. **Formatting** – `ruff format --check`
+2. **Linting** – `ruff check`
+3. **Type checking** – `ty check src`
+4. **Tests** – `pytest` with coverage reporting
+
+Make sure all four checks pass locally before opening a pull request.
+
+## Database migrations
+
+SimDB uses [Alembic](https://alembic.sqlalchemy.org/) to manage database
+schema migrations. Migration scripts live in the `alembic/versions/` directory.
+
+### Configuration
+
+Alembic is configured via `alembic.ini` in the project root. The database URL
+is **not** stored in `alembic.ini`; instead it must be provided through the
+`DATABASE_URL` environment variable:
+
+```bash
+export DATABASE_URL="postgresql+psycopg2://user:password@localhost/simdb"
+```
+
+For SQLite (e.g. during development):
+
+```bash
+export DATABASE_URL="sqlite:///simdb.db"
+```
+
+### Applying migrations
+
+To upgrade the database to the latest schema revision:
+
+```bash
+alembic upgrade head
+```
+
+To upgrade to a specific revision:
+
+```bash
+alembic upgrade <revision_id>
+```
+
+To downgrade by one revision:
+
+```bash
+alembic downgrade -1
+```
+
+### Checking the current revision
+
+```bash
+alembic current
+```
+
+### Viewing migration history
+
+```bash
+alembic history --verbose
+```
+
+### Creating a new migration
+
+After modifying the SQLAlchemy models, generate a new migration script
+automatically with:
+
+```bash
+alembic revision --autogenerate -m "short description of change"
+```
+
+Review the generated file in `alembic/versions/` carefully before applying it,
+as autogenerate may not capture every change (e.g. custom column types or
+server defaults).
+
+To apply the new migration:
+
+```bash
+alembic upgrade head
+```
 
 ## Setting up PostgreSQL Database
-This section will guide to setting up a PostgreSQL server for SimDB.
 
-Setup PostgreSQL configuration and data directory
+This section will guide you through setting up a PostgreSQL server for SimDB.
+
+Setup PostgreSQL configuration and data directory:
+
 ```bash
 mkdir $HOME/Path/To/PostgresSQL_Data
 ```
 
-Initialize database with data directory
+Initialize database with data directory:
+
 ```bash
 initdb -D $HOME/Path/To/PostgresSQL_Data -U simdb
 ```
 
-Start database server
+Start database server:
+
 ```bash
 pg_ctl -D $HOME/Path/To/PostgresSQL_Data/ -l logfile start
 ```
 
-Verify database server status and should prompt /tmp:5432 - accepting connections
+Verify database server status (should show `/tmp:5432 - accepting connections`):
+
 ```bash
 pg_isready
 ```
 
-Creates a database named simdb
+Create a database named `simdb`:
+
 ```bash
 createdb simdb -U simdb
 ```
 
-Access database from command-line. It will prompt simdb=#
+Access database from command-line (will prompt `simdb=#`):
+
 ```bash
 psql -U simdb
 ```
 
-Update [database] section of app.cfg
+Set the `DATABASE_URL` environment variable and run migrations:
+
+```bash
+export DATABASE_URL="postgresql+psycopg2://simdb@localhost/simdb"
+alembic upgrade head
+```
+
+Update the `[database]` section of `app.cfg`:
+
 ```
 ...
 
@@ -88,4 +227,4 @@ host = localhost
 port = 5432
 
 ...
-``` 
+```

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -14,10 +14,12 @@ Create a virtual environment and install SimDB with all development dependencies
 using the `dev` dependency group defined in `pyproject.toml`:
 
 ```bash
-pip install -e --group dev .
+python3 -m venv venv --prompt SimDB
+source venv/bin/activate
+pip install -e . --group dev
 ```
 
-You could also use uv to install all dependencies:
+You could also use [uv](https://docs.astral.sh/uv/getting-started/installation/) to install all dependencies:
 
 ```bash
 uv sync

--- a/src/simdb/cli/remote_api.py
+++ b/src/simdb/cli/remote_api.py
@@ -188,14 +188,14 @@ class RemoteAPI:
             )
         self._remote = remote
         try:
-            self._url: str = config.get_option(f"remote.{remote}.url")
+            self._url: str = config.get_string_option(f"remote.{remote}.url")
         except KeyError:
             raise ValueError(
                 f"Remote '{remote}' not found. Use `simdb remote config add` to add it."
             ) from None
 
         self._api_url: str = f"{self._url}/v{config.api_version}/"
-        self._firewall: Optional[str] = config.get_option(
+        self._firewall: Optional[str] = config.get_string_option(
             f"remote.{remote}.firewall", default=None
         )
 

--- a/src/simdb/remote/app.py
+++ b/src/simdb/remote/app.py
@@ -1,7 +1,11 @@
 import logging
 import os
+from pathlib import Path
 from typing import Optional, Type, cast
 
+from alembic.config import Config as AlembicConfig
+from alembic.migration import MigrationContext
+from alembic.script import ScriptDirectory
 from flask import Flask, jsonify, request
 from flask.json import JSONDecoder, JSONEncoder
 from flask_compress import Compress
@@ -16,6 +20,47 @@ from .core.cache import cache
 from .core.typing import SimDBApp
 
 compress = Compress()
+
+
+# Path to alembic.ini, located at the project root (two levels above this file's
+# package: src/simdb/remote/ -> src/simdb/ -> src/ -> project root)
+_ALEMBIC_INI = Path(__file__).resolve().parents[3] / "alembic.ini"
+
+
+def check_migrations(app: "SimDBApp") -> None:
+    """Check that the database is up-to-date with the latest Alembic migration.
+
+    Logs a warning if the database is behind the head revision, and raises a
+    :class:`RuntimeError` if the database has not been initialised at all (i.e.
+    the ``alembic_version`` table is absent).
+    """
+    alembic_cfg = AlembicConfig(str(_ALEMBIC_INI))
+    script = ScriptDirectory.from_config(alembic_cfg)
+    head_revision = script.get_current_head()
+
+    engine = app.db.engine
+    with engine.connect() as conn:
+        context = MigrationContext.configure(conn)
+        current_revision = context.get_current_revision()
+
+    if current_revision is None:
+        raise RuntimeError(
+            "The database has not been initialised. "
+            f"Run 'DATABASE_URL={engine.url} alembic upgrade head' before starting the "
+            "server. "
+        )
+
+    if current_revision != head_revision:
+        raise RuntimeError(
+            f"Database schema is out of date: current revision is {current_revision}, "
+            f"but the latest revision is {head_revision}. "
+            f"Run 'DATABASE_URL={engine.url} alembic upgrade head' to apply pending "
+            "migrations. "
+        )
+    else:
+        app.logger.info(
+            "Database schema is up to date (revision %s).", current_revision
+        )
 
 
 def create_app(
@@ -65,4 +110,12 @@ def create_app(
     for version, blueprint in blueprints.items():
         app.register_blueprint(blueprint, url_prefix=f"/{version}")
 
+    if not _ALEMBIC_INI.exists():
+        raise RuntimeError(f"Alembic configuration not found at {_ALEMBIC_INI}.")
+
+    try:
+        check_migrations(app)
+    except Exception as exc:
+        app.logger.error("Migration check failed: %s", exc)
+        raise
     return app

--- a/src/simdb/remote/app.py
+++ b/src/simdb/remote/app.py
@@ -5,6 +5,7 @@ from typing import Optional, Type, cast
 
 from alembic.config import Config as AlembicConfig
 from alembic.migration import MigrationContext
+from alembic.operations import Operations
 from alembic.script import ScriptDirectory
 from flask import Flask, jsonify, request
 from flask.json import JSONDecoder, JSONEncoder
@@ -12,6 +13,7 @@ from flask_compress import Compress
 from flask_cors import CORS
 
 from simdb.config import Config
+from simdb.database.models import Base
 from simdb.json import CustomDecoder, CustomEncoder
 
 from .apis import blueprints
@@ -24,7 +26,7 @@ compress = Compress()
 
 # Path to alembic.ini, located at the project root (two levels above this file's
 # package: src/simdb/remote/ -> src/simdb/ -> src/ -> project root)
-_ALEMBIC_INI = Path(__file__).resolve().parents[3] / "alembic.ini"
+_ALEMBIC_INI = Path("alembic.ini")
 
 
 def check_migrations(app: "SimDBApp") -> None:
@@ -61,6 +63,25 @@ def check_migrations(app: "SimDBApp") -> None:
         app.logger.info(
             "Database schema is up to date (revision %s).", current_revision
         )
+
+
+def run_migrations(app: "SimDBApp") -> None:
+    """Run the database migrations."""
+    config = AlembicConfig(_ALEMBIC_INI)
+    config.set_main_option("script_location", "alembic")
+    script = ScriptDirectory.from_config(config)
+
+    def upgrade(rev, context):
+        return script._upgrade_revs("head", rev)
+
+    engine = app.db.engine
+    with engine.connect() as conn:
+        context = MigrationContext.configure(
+            conn, opts={"target_metadata": Base.metadata, "fn": upgrade}
+        )
+
+        with context.begin_transaction(), Operations.context(context):
+            context.run_migrations()
 
 
 def create_app(
@@ -112,6 +133,9 @@ def create_app(
 
     if not _ALEMBIC_INI.exists():
         raise RuntimeError(f"Alembic configuration not found at {_ALEMBIC_INI}.")
+
+    if testing:
+        run_migrations(app)
 
     try:
         check_migrations(app)


### PR DESCRIPTION
This PR adds developer documentation covering the usage of Ruff, Ty, and Alembic.

It also introduces a simdb startup check to verify that the database is on the latest migration revision, ensuring we don't run the application against an outdated schema.