### PR TITLE
Hotfix/documentation-and-bugfix

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -176,7 +176,7 @@ The SimDB client is able to communication with multiple remote servers. You can 
 on your local client using:
 
 ```bash
-simdb remote --list
+simdb remote config list
 ```
 
 First, you will need to add the remote server and set it as default:

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -44,6 +44,9 @@ Before diving into SimDB functionality, it's important to understand these key t
 
 **Workflow**: Typically, you create and manage simulations locally, then push them to a remote SimDB server for sharing. The data referenced by your simulation can be either local (on your machine) or remote (on a data server).
 
+**IMAS Access Layer compatibility**:
+SimDB uses imas-python to read IMAS data. [imas-python](https://pypi.org/project/imas-python/) requires Access Layer 5 (AL5) or later and does not support the older Access Layer 4 (AL4). If your IMAS data was written using AL4 (e.g., MDSplus-based AL4 databases), you must convert it to AL5 format before use. See [AL4 MDSplus data migration](user_guide.md#al4-mdsplus-data-migration) below.
+
 ## Local simulation management
 
 In order to ingest a local simulation you need a manifest file. This is a `yaml` file which contains details about the simulation and what data is associated with it. See the [Tutorial - Creating a simulation manifest](tutorial.md#creating-a-simulation-manifest) for detailed guidelines on how to create a well-formed manifest.
@@ -127,6 +130,26 @@ Without port (uses default):
 `imas://uda.iter.org/uda?path=/work/imas/shared/imasdb/ITER/3/131024/51&backend=hdf5`
 
 **Note:** Ensure that the specified port is accessible through your network firewall. Contact your system administrator if you experience connectivity issues.
+
+## AL4 MDSplus data migration
+SimDB uses [imas-python](https://pypi.org/project/imas-python/) to read IMAS data. `imas-python` requires Access Layer 5 (AL5) or later and **does not support the older Access Layer 4 (AL4).**
+
+If you have existing IMAS data stored in an AL4 MDSplus, you must migrate it to the AL5 directory layout before referencing it in a SimDB manifest. This can be done using the `mdsplusIMASDB4to5` tool provided by IMAS-Core, which creates the new AL5 directory layout with links to the original data files (the original data is not removed).
+```mdsplusIMASDB4to5 [-h] [--dry-run] [-p PATH] [-d DATABASE] [-f]```
+
+| Options                              | Description                                                |
+|--------------------------------------|------------------------------------------------------------|
+| `--dry-run`                          | Print actions but do not perform them                      |
+| `-p PATH`, `--path PATH`             | Specify path where imasdb to map (by default $HOME/public) |
+| `-d DATABASE`, `--database DATABASE` | Specify a database to be map (by default all)              |
+| `-f`, `--force`                      | Force the creation of symlink even if the file exists      |
+
+Once the migration is complete, reference the new AL5 path in your manifest using the mdsplus backend:
+```
+outputs:
+- uri: imas:mdsplus?path=<destination_path>
+```
+For further details on the `mdsplusIMASDB4to5` tool, refer to the IMAS-Core documentation.
 
 ## Remote SimDB servers
 

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -153,6 +153,26 @@ For further details on the `mdsplusIMASDB4to5` tool, refer to the IMAS-Core docu
 
 ## Remote SimDB servers
 
+### Configuration file
+
+SimDB stores remote server configuration in ~/.config/simdb/simdb.cfg. This file is automatically created on the first run of the SimDB CLI and is pre-populated with a connection entry for the default ITER SimDB server:
+```
+[remote "iter"]
+url = https://simdb.iter.org/scenarios/api
+default = True
+username = $USER
+firewall = F5
+```
+
+You can inspect the current remotes at any time with:
+
+```bash
+simdb remote config list
+```
+You can also view or edit `simdb.cfg` directly, but it is recommended to use the `simdb remote config` CLI commands to manage remotes to ensure the file stays well-formed.
+
+**ITER users:** See [Connecting to the ITER remotes](https://simdb.readthedocs.io/en/latest/iter_remotes.html) for a step-by-step guide to setting up and testing the ITER remote connection.
+
 The SimDB CLI is able to interact with remote SimDB servers to push local simulations or to query existing simulations. This is done via the simdb remote command:
 
 ```bash

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -45,7 +45,7 @@ Before diving into SimDB functionality, it's important to understand these key t
 **Workflow**: Typically, you create and manage simulations locally, then push them to a remote SimDB server for sharing. The data referenced by your simulation can be either local (on your machine) or remote (on a data server).
 
 **IMAS Access Layer compatibility**:
-SimDB uses imas-python to read IMAS data. [imas-python](https://pypi.org/project/imas-python/) requires Access Layer 5 (AL5) or later and does not support the older Access Layer 4 (AL4). If your IMAS data was written using AL4 (e.g., MDSplus-based AL4 databases), you must convert it to AL5 format before use. See [AL4 MDSplus data migration](user_guide.md#al4-mdsplus-data-migration) below.
+SimDB uses `imas-python` to read IMAS data. [imas-python](https://pypi.org/project/imas-python/) requires that MDSplus data files to be ingested were written with Access Layer 5 (AL5) or later, and does not support reading  MDSplus files written with Access Layer 4 (AL4). If your IMAS data was written in MDSplus using AL4 (e.g., MDSplus-based AL4 databases), you must first convert it to AL5 format before use. See [AL4 MDSplus data migration](user_guide.md#al4-mdsplus-data-migration) below.
 
 ## Local simulation management
 
@@ -132,7 +132,7 @@ Without port (uses default):
 **Note:** Ensure that the specified port is accessible through your network firewall. Contact your system administrator if you experience connectivity issues.
 
 ## AL4 MDSplus data migration
-SimDB uses [imas-python](https://pypi.org/project/imas-python/) to read IMAS data. `imas-python` requires Access Layer 5 (AL5) or later and **does not support the older Access Layer 4 (AL4).**
+SimDB uses [imas-python](https://pypi.org/project/imas-python/) to read IMAS data. `imas-python` requires that MDSplus data to be read was written with Access Layer 5 (AL5) or later and **does not support the older Access Layer 4 (AL4).**
 
 If you have existing IMAS data stored in an AL4 MDSplus, you must migrate it to the AL5 directory layout before referencing it in a SimDB manifest. This can be done using the `mdsplusIMASDB4to5` tool provided by IMAS-Core, which creates the new AL5 directory layout with links to the original data files (the original data is not removed).
 ```mdsplusIMASDB4to5 [-h] [--dry-run] [-p PATH] [-d DATABASE] [-f]```
@@ -169,9 +169,9 @@ You can inspect the current remotes at any time with:
 ```bash
 simdb remote config list
 ```
-You can also view or edit `simdb.cfg` directly, but it is recommended to use the `simdb remote config` CLI commands to manage remotes to ensure the file stays well-formed.
+You can also view or edit `simdb.cfg` directly, but it is recommended to use the `simdb remote config` CLI commands to manage remotes to ensure the file stays correctly formatted.
 
-**ITER users:** See [Connecting to the ITER remotes](https://simdb.readthedocs.io/en/latest/iter_remotes.html) for a step-by-step guide to setting up and testing the ITER remote connection.
+**ITER users:** See [Connecting to the ITER remotes](https://simdb.readthedocs.io/en/latest/iter_remotes.html) for a step-by-step guide to setting-up and testing the ITER remote connection.
 
 The SimDB CLI is able to interact with remote SimDB servers to push local simulations or to query existing simulations. This is done via the simdb remote command:
 

--- a/src/simdb/database/models/simulation.py
+++ b/src/simdb/database/models/simulation.py
@@ -148,7 +148,7 @@ class Simulation(Base):
 
                 for ids in idss:
                     ids_name, occurrence = extract_ids_occurrence(ids)
-                    check_time(entry, ids, occurrence)
+                    check_time(entry, ids_name, occurrence)
 
                 all_input_idss += idss
 

--- a/validation/iter_scenarios_validation.yaml
+++ b/validation/iter_scenarios_validation.yaml
@@ -14,11 +14,16 @@ code:
   schema:
     name:
       type: string
+      required: true
 time:
   type: numpy
   coerce: numpy
+description:
+  type: string
+  required: true
 global_quantities:
   type: dict
+  required: true
   schema:
     b0:
       type: dict
@@ -26,13 +31,16 @@ global_quantities:
       schema:
         value:
           type: numpy
+          required: true
           coerce: numpy
           lt: 0
     r0:
       type: dict
+      required: true
       schema:
         value:
           type: float
+          required: true
 #         coerce: numpy
           gt: 0
     beta_pol:
@@ -100,6 +108,7 @@ global_quantities:
       schema:
         value:
           type: numpy
+          required: true
           coerce: numpy
           ge: -17000000
           le: 0


### PR DESCRIPTION
- Fixed typo `simdb remote config list`
- Added `IMAS Access Layer compatibility` in user-guide
- Explaining simdb.cfg, its location, default content, and how to manage it
- Fixed separation of ids-name and occurrence of input simulation
- Updated b0, r0, ip and description to mandatory (required=true) in iter-validation-schema