### PR TITLE
Sort IMAS file globs to make checksums platform-independent

### DIFF
--- a/src/simdb/imas/utils.py
+++ b/src/simdb/imas/utils.py
@@ -287,7 +287,7 @@ def imas_files(uri: URI) -> List[Path]:
     path = _get_path(uri)
 
     if backend == "hdf5":
-        return [p.absolute() for p in path.glob("*.h5")]
+        return [p.absolute() for p in sorted(path.glob("*.h5"), key=lambda p: p.name)]
     elif backend == "mdsplus":
         return [
             path / "ids_001.characteristics",
@@ -295,7 +295,7 @@ def imas_files(uri: URI) -> List[Path]:
             path / "ids_001.tree",
         ]
     elif backend == "ascii":
-        return [p.absolute() for p in path.glob("*.ids")]
+        return [p.absolute() for p in sorted(path.glob("*.ids"), key=lambda p: p.name)]
     else:
         raise ValueError(f"Unknown IMAS backend {backend}")
 

--- a/tests/test_imas_utils.py
+++ b/tests/test_imas_utils.py
@@ -1,0 +1,53 @@
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from simdb.imas.utils import imas_files
+from simdb.uri import URI
+
+
+class ImasFilesTests(unittest.TestCase):
+    """Tests for simdb.imas.utils.imas_files.
+
+    The checksum is computed by feeding the files into a single running hash
+    in the order imas_files returns them, so that order must be deterministic
+    and identical across platforms. Path.glob() does not sort, so imas_files
+    sorts explicitly by file name. See utils.imas_files / imas.checksum.checksum.
+    """
+
+    def _make_files(self, directory, names):
+        # Create files in an order that does not match the expected sorted order
+        for name in names:
+            (Path(directory) / name).write_bytes(b"")
+
+    def test_hdf5_files_sorted_by_name(self):
+        names = [
+            "equilibrium.h5",
+            "core_profiles.h5",
+            "master.h5",
+            "summary.h5",
+        ]
+        with TemporaryDirectory() as tmp:
+            self._make_files(tmp, names)
+            uri = URI(f"imas:hdf5?path={tmp}")
+            result = [p.name for p in imas_files(uri)]
+            self.assertEqual(result, sorted(names))
+
+    def test_ascii_files_sorted_by_name(self):
+        names = ["equilibrium.ids", "core_profiles.ids", "summary.ids"]
+        with TemporaryDirectory() as tmp:
+            self._make_files(tmp, names)
+            uri = URI(f"imas:ascii?path={tmp}")
+            result = [p.name for p in imas_files(uri)]
+            self.assertEqual(result, sorted(names))
+
+    def test_hdf5_files_returns_absolute_paths(self):
+        with TemporaryDirectory() as tmp:
+            self._make_files(tmp, ["core_profiles.h5"])
+            uri = URI(f"imas:hdf5?path={tmp}")
+            result = imas_files(uri)
+            self.assertTrue(all(p.is_absolute() for p in result))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`imas.checksum.checksum()` feeds the files returned by `imas_files()` into a single running SHA1 hash in iteration order. `imas_files()` built the HDF5 and ASCII file lists from `Path.glob()`, which returns entries in an arbitrary, filesystem-dependent order. As a result the same byte-identical IMAS data could hash to different checksums on Windows vs Linux.

This sorts the glob results explicitly by file name (`key=lambda p: p.name`) so the iteration order is deterministic and identical across platforms. Sorting by `p.name` rather than relying on `Path` comparison avoids the platform-dependent case-folding of `Path` ordering (Windows folds case, Linux does not).

Adds regression tests for `imas_files` ordering (`tests/test_imas_utils.py`).

Reported issue: glob sorting in `src/simdb/imas/utils.py` is platform dependent.