### PR TITLE
add metadata_dd_version in the metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     "click_option_group>=0.5",
     "distro>=1.8.0",
     "email-validator>=1.1",
-    "imas-python",
+    "imas-python>=2.0.1",
     "netCDF4>=1.5",
     "numpy>=1.14",
     "pydantic>=2.10.6",

--- a/src/simdb/imas/metadata.py
+++ b/src/simdb/imas/metadata.py
@@ -133,7 +133,14 @@ def load_imas_metadata(ids_dist, entry) -> dict:
             f"Could not parse the data dictionary version: {latest_dd_version!r}."
         ) from exc
 
-    if parsed_dd_version.major >= 5:
+    dd_major_version = parsed_dd_version.major
+    if not isinstance(dd_major_version, int):
+        raise RuntimeError(
+            f"Could not determine the major data dictionary version from "
+            f"{latest_dd_version!r}."
+        )
+
+    if dd_major_version >= 5:
         raise RuntimeError(
             f"Unsupported data dictionary version {latest_dd_version!r}: "
             "expected a major version lower than 5."

--- a/src/simdb/imas/metadata.py
+++ b/src/simdb/imas/metadata.py
@@ -5,10 +5,9 @@ from typing import Any, Dict
 import imas
 import imas.dd_zip
 import imas.ids_defs
+from semantic_version import Version
 
 from simdb.remote.models import _array_to_range
-
-METADATA_DD_VERSION_KEY = "metadata_dd_version"
 
 
 class MetricException(Exception):
@@ -125,9 +124,22 @@ def load_imas_metadata(ids_dist, entry) -> dict:
 
     latest_dd_version = imas.dd_zip.latest_dd_version()
     if latest_dd_version is None:
-        raise ValueError("Could not determine the latest DD version.")
+        raise RuntimeError("Could not determine the data dictionary version.")
 
-    metadata = {METADATA_DD_VERSION_KEY: latest_dd_version}
+    try:
+        parsed_dd_version = Version(latest_dd_version)
+    except ValueError as exc:
+        raise RuntimeError(
+            f"Could not parse the data dictionary version: {latest_dd_version!r}."
+        ) from exc
+
+    if parsed_dd_version.major >= 5:
+        raise RuntimeError(
+            f"Unsupported data dictionary version {latest_dd_version!r}: "
+            "expected a major version lower than 5."
+        )
+
+    metadata = {"metadata_dd_version": latest_dd_version}
     for ids_name, _v in ids_dist.items():
         ids = entry.get(ids_name, autoconvert=False)
         ids = imas.convert_ids(ids, latest_dd_version)

--- a/src/simdb/imas/metadata.py
+++ b/src/simdb/imas/metadata.py
@@ -140,10 +140,9 @@ def load_imas_metadata(ids_dist, entry) -> dict:
             f"{latest_dd_version!r}."
         )
 
-    if dd_major_version >= 5:
+    if dd_major_version > 4:
         raise RuntimeError(
             f"Unsupported data dictionary version {latest_dd_version!r}: "
-            "expected a major version lower than 5."
         )
 
     metadata = {"metadata_dd_version": latest_dd_version}

--- a/src/simdb/imas/metadata.py
+++ b/src/simdb/imas/metadata.py
@@ -8,6 +8,8 @@ import imas.ids_defs
 
 from simdb.remote.models import _array_to_range
 
+METADATA_DD_VERSION_KEY = "metadata_dd_version"
+
 
 class MetricException(Exception):
     pass
@@ -121,13 +123,13 @@ def load_imas_metadata(ids_dist, entry) -> dict:
     :return: Dictionary containing metadata.
     """
 
-    metadata = {}
+    latest_dd_version = imas.dd_zip.latest_dd_version()
+    if latest_dd_version is None:
+        raise ValueError("Could not determine the latest DD version.")
+
+    metadata = {METADATA_DD_VERSION_KEY: latest_dd_version}
     for ids_name, _v in ids_dist.items():
         ids = entry.get(ids_name, autoconvert=False)
-        # Explicitly convert the IDS to the target version
-        latest_dd_version = imas.dd_zip.latest_dd_version()
-        if latest_dd_version is None:
-            raise ValueError("Could not determine the latest DD version.")
         ids = imas.convert_ids(ids, latest_dd_version)
         for node in imas.util.tree_iter(ids):
             metadata[extract_ids_path(str(node.coordinates)).replace("/", ".")] = (  # type: ignore

--- a/uv.lock
+++ b/uv.lock
@@ -2863,7 +2863,7 @@ requires-dist = [
     { name = "flask-cors", marker = "extra == 'server'", specifier = ">=3" },
     { name = "flask-mail", marker = "extra == 'server'", specifier = "~=0.9.1" },
     { name = "flask-restx", marker = "extra == 'server'", specifier = ">=1.0.0" },
-    { name = "imas-python" },
+    { name = "imas-python", specifier = ">=2.0.1" },
     { name = "imas-simdb", extras = ["auth-ad", "auth-keycloak", "auth-ldap"], marker = "extra == 'auth'" },
     { name = "imas-simdb", extras = ["imas-validator", "postgres", "server"], marker = "extra == 'all'" },
     { name = "imas-validator", marker = "extra == 'imas-validator'", specifier = ">=1.0.0" },


### PR DESCRIPTION
Store IMAS Data Dictionary version used when extracting Summary IDS metadata during  simulation ingestion. This adds `metadata_dd_version` entry to each ingested simulation.