### PR TITLE
added simulation's metadata query endpoint

### DIFF
--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -326,8 +326,8 @@ To filter simulations and return selected quantities from their metadata, use
 
 ```bash
 simdb remote data-query \
-  'summary.global_quantities.ip.value=agt:-5' \
-  'summary.global_quantities.ip.value=alt:10' \
+  'summary.global_quantities.ip.value=gt:-5' \
+  'summary.global_quantities.ip.value=lt:10' \
   --quantity 'ip=summary.global_quantities.ip.value' \
   --quantity 'q95=summary.global_quantities.q_95.value'
 ```
@@ -343,12 +343,12 @@ POST /v1.3/simulations/data/query
   "filters": [
     {
       "field": "summary.global_quantities.ip.value",
-      "operator": "agt",
+      "operator": "gt",
       "value": -5
     },
     {
       "field": "summary.global_quantities.ip.value",
-      "operator": "alt",
+      "operator": "lt",
       "value": 10
     }
   ],
@@ -364,9 +364,8 @@ POST /v1.3/simulations/data/query
 }
 ```
 
-`data-query` uses the existing metadata query operators. Use `gt`, `ge`, `lt`, and `le`
-for scalar numeric metadata. Numeric arrays are stored as minimum and maximum values;
-use `agt`/`age` to compare their maximum and `alt`/`ale` to compare their minimum.
+For range metadata, `gt`/`ge` compare the minimum and `lt`/`le` compare the maximum.
+Scalar numeric metadata keeps the existing comparison behavior.
 
 ## Accessing Simulation Metadata via the SimDB Dashboard
 

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -321,6 +321,54 @@ and you can see all the stored metadata against a remote simulation using:
 simdb remote info <SIM_ID>
 ```
 
+To filter simulations and return selected quantities from their metadata, use
+`data-query`. Each quantity has a response name and a metadata path:
+
+```bash
+simdb remote data-query \
+  'summary.global_quantities.ip.value=gt:-5' \
+  'summary.global_quantities.ip.value=lt:10' \
+  --quantity 'ip=summary.global_quantities.ip.value' \
+  --quantity 'q95=summary.global_quantities.q_95.value'
+```
+
+The corresponding REST endpoint accepts the same operation as a structured request:
+
+```text
+POST /v1.2/simulations/data/query
+```
+
+```json
+{
+  "filters": [
+    {
+      "field": "summary.global_quantities.ip.value",
+      "operator": "gt",
+      "value": -5
+    },
+    {
+      "field": "summary.global_quantities.ip.value",
+      "operator": "lt",
+      "value": 10
+    }
+  ],
+  "quantities": [
+    {
+      "name": "ip",
+      "path": "summary.global_quantities.ip.value",
+      "source": "metadata"
+    }
+  ],
+  "page": 1,
+  "limit": 100
+}
+```
+
+Numeric arrays are stored in metadata as their minimum and maximum. For range metadata,
+`gt` and `ge` compare the minimum while `lt` and `le` compare the maximum, so combining
+lower and upper bounds requires every original value to be inside them. Use `agt`,
+`age`, `alt`, or `ale` when any value may satisfy a bound.
+
 ## Accessing Simulation Metadata via the SimDB Dashboard
 
 You can view a simulation's metadata directly in the SimDB dashboard using its UUID.

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -335,7 +335,7 @@ simdb remote data-query \
 The corresponding REST endpoint accepts the same operation as a structured request:
 
 ```text
-POST /v1.2/simulations/data/query
+POST /v1.3/simulations/data/query
 ```
 
 ```json

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -326,8 +326,8 @@ To filter simulations and return selected quantities from their metadata, use
 
 ```bash
 simdb remote data-query \
-  'summary.global_quantities.ip.value=gt:-5' \
-  'summary.global_quantities.ip.value=lt:10' \
+  'summary.global_quantities.ip.value=agt:-5' \
+  'summary.global_quantities.ip.value=alt:10' \
   --quantity 'ip=summary.global_quantities.ip.value' \
   --quantity 'q95=summary.global_quantities.q_95.value'
 ```
@@ -343,12 +343,12 @@ POST /v1.3/simulations/data/query
   "filters": [
     {
       "field": "summary.global_quantities.ip.value",
-      "operator": "gt",
+      "operator": "agt",
       "value": -5
     },
     {
       "field": "summary.global_quantities.ip.value",
-      "operator": "lt",
+      "operator": "alt",
       "value": 10
     }
   ],
@@ -364,10 +364,9 @@ POST /v1.3/simulations/data/query
 }
 ```
 
-Numeric arrays are stored in metadata as their minimum and maximum. For range metadata,
-`gt` and `ge` compare the minimum while `lt` and `le` compare the maximum, so combining
-lower and upper bounds requires every original value to be inside them. Use `agt`,
-`age`, `alt`, or `ale` when any value may satisfy a bound.
+`data-query` uses the existing metadata query operators. Use `gt`, `ge`, `lt`, and `le`
+for scalar numeric metadata. Numeric arrays are stored as minimum and maximum values;
+use `agt`/`age` to compare their maximum and `alt`/`ale` to compare their minimum.
 
 ## Accessing Simulation Metadata via the SimDB Dashboard
 

--- a/src/simdb/cli/commands/remote.py
+++ b/src/simdb/cli/commands/remote.py
@@ -1,3 +1,4 @@
+import json
 import re
 import shutil
 import sys
@@ -12,6 +13,7 @@ from semantic_version import Version
 from simdb.cli.remote_api import RemoteAPI
 from simdb.database.models.simulation import Simulation
 from simdb.notifications import Notification
+from simdb.query import QueryType, parse_query_arg
 
 from . import check_meta_args, pass_config
 from .utils import print_simulations, print_trace
@@ -532,6 +534,85 @@ def remote_query(
     print_simulations(
         simulations, verbose=config.verbose, metadata_names=names, show_uuid=show_uuid
     )
+
+
+@remote.command("data-query", cls=remote_command_cls())
+@pass_api
+@click.argument("constraints", nargs=-1)
+@click.option(
+    "-q",
+    "--quantity",
+    "quantities",
+    multiple=True,
+    required=True,
+    metavar="NAME=METADATA_PATH",
+    help="Stored metadata quantity to return. May be provided multiple times.",
+)
+@click.option(
+    "-l",
+    "--limit",
+    default=100,
+    show_default=True,
+    callback=validate_positive,
+    help="Maximum simulations returned per page.",
+)
+@click.option(
+    "--page",
+    default=1,
+    show_default=True,
+    callback=validate_positive,
+    help="One-indexed result page.",
+)
+def remote_data_query(
+    api: RemoteAPI,
+    constraints: Tuple[str, ...],
+    quantities: Tuple[str, ...],
+    limit: int,
+    page: int,
+):
+    """Filter simulations and return quantities from remote database metadata.
+
+    CONSTRAINTS use the same ``NAME=[operator:]VALUE`` syntax as ``remote query``.
+    """
+    filters = []
+    for constraint in constraints:
+        if "=" not in constraint:
+            raise click.ClickException(f"Invalid constraint {constraint}.")
+        field, expression = constraint.split("=", 1)
+        value, operator = parse_query_arg(expression)
+        if operator == QueryType.NONE:
+            raise click.ClickException(
+                f"Invalid constraint {constraint}; a value or operator is required."
+            )
+        try:
+            typed_value = json.loads(value)
+        except json.JSONDecodeError:
+            typed_value = value
+        filters.append(
+            {
+                "field": field,
+                "operator": operator.name.lower(),
+                "value": None if operator == QueryType.EXIST else typed_value,
+            }
+        )
+
+    requested_quantities = []
+    for quantity in quantities:
+        if "=" not in quantity:
+            raise click.ClickException(
+                f"Invalid quantity {quantity}; expected NAME=METADATA_PATH."
+            )
+        name, path = quantity.split("=", 1)
+        if not name or not path:
+            raise click.ClickException(
+                f"Invalid quantity {quantity}; expected NAME=METADATA_PATH."
+            )
+        requested_quantities.append({"name": name, "path": path, "source": "metadata"})
+
+    result = api.query_simulation_data(
+        filters, requested_quantities, limit=limit, page=page
+    )
+    click.echo(json.dumps(result, indent=2))
 
 
 @remote.group(cls=RemoteSubGroup)

--- a/src/simdb/cli/commands/remote.py
+++ b/src/simdb/cli/commands/remote.py
@@ -584,15 +584,11 @@ def remote_data_query(
             raise click.ClickException(
                 f"Invalid constraint {constraint}; a value or operator is required."
             )
-        try:
-            typed_value = json.loads(value)
-        except json.JSONDecodeError:
-            typed_value = value
         filters.append(
             {
                 "field": field,
                 "operator": operator.name.lower(),
-                "value": None if operator == QueryType.EXIST else typed_value,
+                "value": None if operator == QueryType.EXIST else value,
             }
         )
 

--- a/src/simdb/cli/remote_api.py
+++ b/src/simdb/cli/remote_api.py
@@ -712,7 +712,7 @@ class RemoteAPI:
         data = res.json(cls=CustomDecoder)
         return [Simulation.from_data(sim) for sim in data["results"]]
 
-    @versioned_method("v1.2", "v1.3")
+    @versioned_method("v1.3")
     @try_request
     def query_simulation_data(
         self,

--- a/src/simdb/cli/remote_api.py
+++ b/src/simdb/cli/remote_api.py
@@ -714,6 +714,27 @@ class RemoteAPI:
 
     @versioned_method("v1.2", "v1.3")
     @try_request
+    def query_simulation_data(
+        self,
+        filters: List[Dict[str, Any]],
+        quantities: List[Dict[str, str]],
+        limit: int = 100,
+        page: int = 1,
+    ) -> Dict[str, Any]:
+        """Filter remote simulations and select stored metadata quantities."""
+        response = self.post(
+            "simulations/data/query",
+            {
+                "filters": filters,
+                "quantities": quantities,
+                "limit": limit,
+                "page": page,
+            },
+        )
+        return response.json()
+
+    @versioned_method("v1.2")
+    @try_request
     def delete_simulation(self, sim_id: str) -> Dict:
         res = self.delete("simulation/" + sim_id, {})
         return res.json()

--- a/src/simdb/database/database.py
+++ b/src/simdb/database/database.py
@@ -486,10 +486,10 @@ class Database:
                 cmp_op(),
             )
 
-        def _num_with_op(cmp_op):
+        def _scalar_or_range_cmp(scalar_cmp_op, range_cmp_op):
             if cmp_float is None:
                 return None
-            return _number_cmp(cmp_op)
+            return sql_or(_number_cmp(scalar_cmp_op), range_cmp_op())
 
         if query_type == QueryType.EQ:
             return _string_cmp(lambda a, b: a == b)
@@ -500,13 +500,25 @@ class Database:
         elif query_type == QueryType.NI:
             return _string_cmp(lambda a, b: a.notilike(f"%{b}%"))
         elif query_type == QueryType.GT:
-            return _num_with_op(lambda: sql_cast(json_access, Float) > cmp_float)
+            return _scalar_or_range_cmp(
+                lambda: sql_cast(json_access, Float) > cmp_float,
+                lambda: sql_cast(json_min, Float) > cmp_float,
+            )
         elif query_type == QueryType.GE:
-            return _num_with_op(lambda: sql_cast(json_access, Float) >= cmp_float)
+            return _scalar_or_range_cmp(
+                lambda: sql_cast(json_access, Float) >= cmp_float,
+                lambda: sql_cast(json_min, Float) >= cmp_float,
+            )
         elif query_type == QueryType.LT:
-            return _num_with_op(lambda: sql_cast(json_access, Float) < cmp_float)
+            return _scalar_or_range_cmp(
+                lambda: sql_cast(json_access, Float) < cmp_float,
+                lambda: sql_cast(json_max, Float) < cmp_float,
+            )
         elif query_type == QueryType.LE:
-            return _num_with_op(lambda: sql_cast(json_access, Float) <= cmp_float)
+            return _scalar_or_range_cmp(
+                lambda: sql_cast(json_access, Float) <= cmp_float,
+                lambda: sql_cast(json_max, Float) <= cmp_float,
+            )
         elif query_type == QueryType.AGT:
             if cmp_float is not None:
                 return sql_cast(json_max, Float) > cmp_float

--- a/src/simdb/database/database.py
+++ b/src/simdb/database/database.py
@@ -465,13 +465,26 @@ class Database:
 
         try:
             cmp_float = float(compare_value)
-        except ValueError:
+        except (TypeError, ValueError):
             cmp_float = None
 
         def _string_cmp(op):
             if dialect == "postgresql":
                 return op(json_access, compare_value)
             return op(func.cast(json_access, String), compare_value)
+
+        def _boolean_cmp(op):
+            expected = compare_value.lower()
+            if dialect == "postgresql":
+                return sql_and(
+                    func.jsonb_typeof(json_obj) == "boolean",
+                    op(json_access, expected),
+                )
+            json_type = func.json_type(column, f'$."{key}"')
+            return sql_and(
+                json_type.in_(["true", "false"]),
+                op(json_type, expected),
+            )
 
         def _number_cmp(cmp_op):
             if dialect == "postgresql":
@@ -486,27 +499,43 @@ class Database:
                 cmp_op(),
             )
 
-        def _num_with_op(cmp_op):
+        def _scalar_or_range_cmp(scalar_cmp, range_cmp):
             if cmp_float is None:
                 return None
-            return _number_cmp(cmp_op)
+            return sql_or(_number_cmp(scalar_cmp), range_cmp())
 
         if query_type == QueryType.EQ:
+            if compare_value.lower() in {"true", "false"}:
+                return _boolean_cmp(lambda a, b: a == b)
             return _string_cmp(lambda a, b: a == b)
         elif query_type == QueryType.NE:
+            if compare_value.lower() in {"true", "false"}:
+                return _boolean_cmp(lambda a, b: a != b)
             return _string_cmp(lambda a, b: a != b)
         elif query_type == QueryType.IN:
             return _string_cmp(lambda a, b: a.ilike(f"%{b}%"))
         elif query_type == QueryType.NI:
             return _string_cmp(lambda a, b: a.notilike(f"%{b}%"))
         elif query_type == QueryType.GT:
-            return _num_with_op(lambda: sql_cast(json_access, Float) > cmp_float)
+            return _scalar_or_range_cmp(
+                lambda: sql_cast(json_access, Float) > cmp_float,
+                lambda: sql_cast(json_min, Float) > cmp_float,
+            )
         elif query_type == QueryType.GE:
-            return _num_with_op(lambda: sql_cast(json_access, Float) >= cmp_float)
+            return _scalar_or_range_cmp(
+                lambda: sql_cast(json_access, Float) >= cmp_float,
+                lambda: sql_cast(json_min, Float) >= cmp_float,
+            )
         elif query_type == QueryType.LT:
-            return _num_with_op(lambda: sql_cast(json_access, Float) < cmp_float)
+            return _scalar_or_range_cmp(
+                lambda: sql_cast(json_access, Float) < cmp_float,
+                lambda: sql_cast(json_max, Float) < cmp_float,
+            )
         elif query_type == QueryType.LE:
-            return _num_with_op(lambda: sql_cast(json_access, Float) <= cmp_float)
+            return _scalar_or_range_cmp(
+                lambda: sql_cast(json_access, Float) <= cmp_float,
+                lambda: sql_cast(json_max, Float) <= cmp_float,
+            )
         elif query_type == QueryType.AGT:
             if cmp_float is not None:
                 return sql_cast(json_max, Float) > cmp_float

--- a/src/simdb/database/database.py
+++ b/src/simdb/database/database.py
@@ -465,26 +465,13 @@ class Database:
 
         try:
             cmp_float = float(compare_value)
-        except (TypeError, ValueError):
+        except ValueError:
             cmp_float = None
 
         def _string_cmp(op):
             if dialect == "postgresql":
                 return op(json_access, compare_value)
             return op(func.cast(json_access, String), compare_value)
-
-        def _boolean_cmp(op):
-            expected = compare_value.lower()
-            if dialect == "postgresql":
-                return sql_and(
-                    func.jsonb_typeof(json_obj) == "boolean",
-                    op(json_access, expected),
-                )
-            json_type = func.json_type(column, f'$."{key}"')
-            return sql_and(
-                json_type.in_(["true", "false"]),
-                op(json_type, expected),
-            )
 
         def _number_cmp(cmp_op):
             if dialect == "postgresql":
@@ -499,43 +486,27 @@ class Database:
                 cmp_op(),
             )
 
-        def _scalar_or_range_cmp(scalar_cmp, range_cmp):
+        def _num_with_op(cmp_op):
             if cmp_float is None:
                 return None
-            return sql_or(_number_cmp(scalar_cmp), range_cmp())
+            return _number_cmp(cmp_op)
 
         if query_type == QueryType.EQ:
-            if compare_value.lower() in {"true", "false"}:
-                return _boolean_cmp(lambda a, b: a == b)
             return _string_cmp(lambda a, b: a == b)
         elif query_type == QueryType.NE:
-            if compare_value.lower() in {"true", "false"}:
-                return _boolean_cmp(lambda a, b: a != b)
             return _string_cmp(lambda a, b: a != b)
         elif query_type == QueryType.IN:
             return _string_cmp(lambda a, b: a.ilike(f"%{b}%"))
         elif query_type == QueryType.NI:
             return _string_cmp(lambda a, b: a.notilike(f"%{b}%"))
         elif query_type == QueryType.GT:
-            return _scalar_or_range_cmp(
-                lambda: sql_cast(json_access, Float) > cmp_float,
-                lambda: sql_cast(json_min, Float) > cmp_float,
-            )
+            return _num_with_op(lambda: sql_cast(json_access, Float) > cmp_float)
         elif query_type == QueryType.GE:
-            return _scalar_or_range_cmp(
-                lambda: sql_cast(json_access, Float) >= cmp_float,
-                lambda: sql_cast(json_min, Float) >= cmp_float,
-            )
+            return _num_with_op(lambda: sql_cast(json_access, Float) >= cmp_float)
         elif query_type == QueryType.LT:
-            return _scalar_or_range_cmp(
-                lambda: sql_cast(json_access, Float) < cmp_float,
-                lambda: sql_cast(json_max, Float) < cmp_float,
-            )
+            return _num_with_op(lambda: sql_cast(json_access, Float) < cmp_float)
         elif query_type == QueryType.LE:
-            return _scalar_or_range_cmp(
-                lambda: sql_cast(json_access, Float) <= cmp_float,
-                lambda: sql_cast(json_max, Float) <= cmp_float,
-            )
+            return _num_with_op(lambda: sql_cast(json_access, Float) <= cmp_float)
         elif query_type == QueryType.AGT:
             if cmp_float is not None:
                 return sql_cast(json_max, Float) > cmp_float

--- a/src/simdb/remote/apis/simulation_data_query.py
+++ b/src/simdb/remote/apis/simulation_data_query.py
@@ -1,0 +1,88 @@
+"""Database-backed simulation filtering and quantity selection endpoint."""
+
+from typing import Annotated
+
+from flask_restx import Namespace, Resource
+
+from simdb.query import QueryType
+from simdb.remote.core.auth import User, requires_auth
+from simdb.remote.core.pydantic_utils import Body, pydantic_validate
+from simdb.remote.core.typing import current_app
+from simdb.remote.models import (
+    PaginatedResponse,
+    SimulationDataQuantityResult,
+    SimulationDataQueryItem,
+    SimulationDataQueryRequest,
+)
+
+api = Namespace("simulation-data-query", path="/")
+
+
+def _filter_value(value) -> str:
+    if isinstance(value, bool):
+        return str(value).lower()
+    return "" if value is None else str(value)
+
+
+@api.route("/simulations/data/query")
+class SimulationDataQuery(Resource):
+    @requires_auth()
+    @pydantic_validate(api)
+    def post(
+        self,
+        user: User,
+        body: Annotated[SimulationDataQueryRequest, Body()],
+    ) -> PaginatedResponse[SimulationDataQueryItem]:
+        """Filter simulations and retrieve quantities from stored metadata."""
+        constraints = [
+            (
+                item.field,
+                _filter_value(item.value),
+                QueryType[item.operator.upper()],
+            )
+            for item in body.filters
+        ]
+        metadata_paths = list(dict.fromkeys(item.path for item in body.quantities))
+
+        count, rows = current_app.db.query_meta_data(
+            constraints,
+            metadata_paths,
+            limit=body.limit,
+            page=body.page,
+            sort_by=body.sort_by,
+            sort_asc=body.sort_asc,
+        )
+
+        results = []
+        for row in rows:
+            metadata = {
+                item["element"]: item["value"] for item in row.get("metadata", [])
+            }
+            quantities = {}
+            missing = []
+            for requested in body.quantities:
+                if requested.path not in metadata:
+                    missing.append(requested.name)
+                    continue
+                quantities[requested.name] = SimulationDataQuantityResult(
+                    source=requested.source,
+                    path=requested.path,
+                    value=metadata[requested.path],
+                )
+
+            results.append(
+                SimulationDataQueryItem(
+                    uuid=row["uuid"],
+                    alias=row["alias"],
+                    datetime=row["datetime"],
+                    quantities=quantities,
+                    missing=missing,
+                )
+            )
+
+        return PaginatedResponse[SimulationDataQueryItem](
+            count=count,
+            page=body.page,
+            limit=body.limit,
+            results=results,
+        )

--- a/src/simdb/remote/apis/v1_2/__init__.py
+++ b/src/simdb/remote/apis/v1_2/__init__.py
@@ -4,7 +4,6 @@ from flask_restx import Api, Resource
 
 from simdb.remote.apis.files import api as file_ns
 from simdb.remote.apis.metadata import api as metadata_ns
-from simdb.remote.apis.simulation_data_query import api as simulation_data_query_ns
 from simdb.remote.apis.watchers import api as watcher_ns
 from simdb.remote.core.auth import TokenAuthenticator, User, requires_auth
 from simdb.remote.core.pydantic_utils import pydantic_validate
@@ -32,7 +31,7 @@ api = Api(
 )
 
 api.add_namespace(sim_ns)
-namespaces = [metadata_ns, watcher_ns, file_ns, sim_ns, simulation_data_query_ns]
+namespaces = [metadata_ns, watcher_ns, file_ns, sim_ns]
 
 
 @api.route("/staging_dir", defaults={"sim_hex": None})

--- a/src/simdb/remote/apis/v1_2/__init__.py
+++ b/src/simdb/remote/apis/v1_2/__init__.py
@@ -4,6 +4,7 @@ from flask_restx import Api, Resource
 
 from simdb.remote.apis.files import api as file_ns
 from simdb.remote.apis.metadata import api as metadata_ns
+from simdb.remote.apis.simulation_data_query import api as simulation_data_query_ns
 from simdb.remote.apis.watchers import api as watcher_ns
 from simdb.remote.core.auth import TokenAuthenticator, User, requires_auth
 from simdb.remote.core.pydantic_utils import pydantic_validate
@@ -31,7 +32,7 @@ api = Api(
 )
 
 api.add_namespace(sim_ns)
-namespaces = [metadata_ns, watcher_ns, file_ns, sim_ns]
+namespaces = [metadata_ns, watcher_ns, file_ns, sim_ns, simulation_data_query_ns]
 
 
 @api.route("/staging_dir", defaults={"sim_hex": None})

--- a/src/simdb/remote/apis/v1_3/__init__.py
+++ b/src/simdb/remote/apis/v1_3/__init__.py
@@ -2,6 +2,7 @@ from flask_restx import Api
 
 from simdb.remote.apis.files import api as file_ns
 from simdb.remote.apis.metadata import api as metadata_ns
+from simdb.remote.apis.simulation_data_query import api as simulation_data_query_ns
 from simdb.remote.apis.v1_2 import StagingDirectory
 from simdb.remote.apis.v1_2 import api as api_v1_2
 from simdb.remote.apis.v1_2.simulations import api as sim_ns
@@ -28,7 +29,14 @@ api = Api(
     doc="/docs",
 )
 
-namespaces = [metadata_ns, watcher_ns, file_ns, sim_ns, data_ns]
+namespaces = [
+    metadata_ns,
+    watcher_ns,
+    file_ns,
+    sim_ns,
+    data_ns,
+    simulation_data_query_ns,
+]
 
 api.route("/staging_dir", defaults={"sim_hex": None})(StagingDirectory)
 api.route("/staging_dir/<string:sim_hex>")(StagingDirectory)

--- a/src/simdb/remote/models.py
+++ b/src/simdb/remote/models.py
@@ -390,6 +390,158 @@ class SimulationListItem(BaseModel):
     """Simulation metadata."""
 
 
+MetadataQueryOperator = Literal[
+    "eq",
+    "ne",
+    "in",
+    "ni",
+    "gt",
+    "ge",
+    "lt",
+    "le",
+    "agt",
+    "age",
+    "alt",
+    "ale",
+    "exist",
+]
+"""Operators supported by database metadata queries."""
+
+
+class SimulationDataFilter(BaseModel):
+    """A filter applied to stored simulation metadata."""
+
+    field: str = Field(min_length=1)
+    """Metadata key to filter on."""
+    operator: MetadataQueryOperator = "eq"
+    """Comparison operator."""
+    value: Optional[Union[str, int, float, bool]] = None
+    """Comparison value. Omit only when using the ``exist`` operator."""
+
+    @model_validator(mode="after")
+    def validate_filter(self):
+        self.field = self.field.strip()
+        if not self.field:
+            raise ValueError("field must not be blank")
+
+        if self.operator != "exist" and self.value is None:
+            raise ValueError("value is required unless operator is 'exist'")
+
+        scalar_operators = {"eq", "ne", "in", "ni", "gt", "ge", "lt", "le"}
+        allowed_reserved_operators = {
+            "alias": {"eq", "ne", "in", "ni", "exist"},
+            "uuid": {"eq", "ne", "in", "ni", "exist"},
+            "creation_date": {"eq", "ne", "gt", "ge", "lt", "le", "exist"},
+        }
+        allowed = allowed_reserved_operators.get(self.field)
+        if allowed is not None and self.operator not in allowed:
+            raise ValueError(
+                f"operator '{self.operator}' is not supported for field '{self.field}'"
+            )
+
+        if isinstance(self.value, bool) and self.operator not in {"eq", "ne"}:
+            raise ValueError("Boolean filter values support only 'eq' and 'ne'")
+
+        numeric_operators = {
+            "gt",
+            "ge",
+            "lt",
+            "le",
+            "agt",
+            "age",
+            "alt",
+            "ale",
+        }
+        if self.operator in numeric_operators and self.field != "creation_date":
+            assert self.value is not None
+            try:
+                float(self.value)
+            except (TypeError, ValueError) as exc:
+                raise ValueError(
+                    f"operator '{self.operator}' requires a numeric value"
+                ) from exc
+
+        if self.field == "uuid" and self.operator in {"eq", "ne"}:
+            try:
+                UUID(str(self.value))
+            except ValueError as exc:
+                raise ValueError("invalid UUID filter value") from exc
+
+        if (
+            self.field == "creation_date"
+            and self.operator in scalar_operators
+            and self.operator not in {"in", "ni"}
+        ):
+            try:
+                dt.strptime(str(self.value).replace("_", ":"), "%Y-%m-%d %H:%M:%S")
+            except ValueError as exc:
+                raise ValueError("creation_date must use YYYY-MM-DD HH_MM_SS") from exc
+        return self
+
+
+class SimulationDataQuantity(BaseModel):
+    """A quantity requested for every matching simulation."""
+
+    name: str = Field(min_length=1)
+    """Name used for this quantity in the response."""
+    path: str = Field(min_length=1)
+    """Stored metadata key. May later identify another supported data source."""
+    source: Literal["metadata"] = "metadata"
+    """Quantity provider. Only database metadata is currently supported."""
+
+
+class SimulationDataQueryRequest(BaseModel):
+    """Filter simulations and select quantities from stored metadata."""
+
+    filters: List[SimulationDataFilter] = Field(default_factory=list, max_length=50)
+    """Metadata constraints. All filters are combined with logical AND."""
+    quantities: List[SimulationDataQuantity] = Field(min_length=1, max_length=50)
+    """Quantities returned for each matching simulation."""
+    page: int = Field(1, ge=1)
+    """One-indexed result page."""
+    limit: int = Field(100, ge=1, le=1000)
+    """Maximum simulations returned on this page."""
+    sort_by: Literal["", "alias", "uuid", "datetime"] = ""
+    """Optional simulation field used for sorting."""
+    sort_asc: bool = False
+    """Sort ascending when true, descending otherwise."""
+
+    @model_validator(mode="after")
+    def require_unique_quantity_names(self):
+        names = [quantity.name for quantity in self.quantities]
+        if len(names) != len(set(names)):
+            raise ValueError("quantity names must be unique")
+        return self
+
+
+class SimulationDataQuantityResult(BaseModel):
+    """Value returned by a quantity provider."""
+
+    source: Literal["metadata"]
+    """Provider used to retrieve the quantity."""
+    path: str
+    """Provider-specific quantity path."""
+    value: MetadataValue
+    """Retrieved value."""
+
+
+class SimulationDataQueryItem(BaseModel):
+    """Selected quantities for one matching simulation."""
+
+    uuid: CustomUUID
+    """Simulation UUID."""
+    alias: Optional[str] = None
+    """Simulation alias."""
+    datetime: str
+    """Simulation creation timestamp."""
+    quantities: Dict[str, SimulationDataQuantityResult] = Field(default_factory=dict)
+    """Retrieved quantities, keyed by their requested names."""
+    missing: List[str] = Field(default_factory=list)
+    """Requested quantity names not present in this simulation's metadata."""
+    errors: Dict[str, str] = Field(default_factory=dict)
+    """Provider errors keyed by requested quantity name."""
+
+
 T = TypeVar("T")
 """Type variable for generic paginated responses."""
 

--- a/src/simdb/remote/models.py
+++ b/src/simdb/remote/models.py
@@ -431,7 +431,7 @@ class SimulationDataFilter(BaseModel):
         allowed_reserved_operators = {
             "alias": {"eq", "ne", "in", "ni", "exist"},
             "uuid": {"eq", "ne", "in", "ni", "exist"},
-            "creation_date": {"eq", "ne", "gt", "ge", "lt", "le", "exist"},
+            "creation_date": {"eq", "ne", "gt", "ge", "lt", "le"},
         }
         allowed = allowed_reserved_operators.get(self.field)
         if allowed is not None and self.operator not in allowed:

--- a/tests/cli/test_cli_remote_command.py
+++ b/tests/cli/test_cli_remote_command.py
@@ -1,8 +1,10 @@
 from unittest import mock
 
+import pytest
 from click.testing import CliRunner
 from utils import config_test_file
 
+from simdb.cli.remote_api import RemoteAPI, RemoteError
 from simdb.cli.simdb import cli
 from simdb.notifications import Notification
 
@@ -349,8 +351,8 @@ def test_remote_data_query_command(
     get_endpoints,
     get_server_authentication,
 ):
-    get_endpoints.return_value = ["v1", "v1.1", "v1.1.1", "v1.2"]
-    get_api_version.return_value = "1.2"
+    get_endpoints.return_value = ["v1", "v1.1", "v1.1.1", "v1.2", "v1.3"]
+    get_api_version.return_value = "1.3"
     get_server_version.return_value = "0.11"
     get_server_authentication.return_value = "None"
     query_simulation_data.return_value = {
@@ -372,8 +374,8 @@ def test_remote_data_query_command(
             "25",
             "--quantity",
             "ip=summary.global_quantities.ip.value",
-            "summary.global_quantities.ip.value=gt:-5",
-            "summary.global_quantities.ip.value=lt:10",
+            "summary.global_quantities.ip.value=agt:-5",
+            "summary.global_quantities.ip.value=alt:10",
             "summary.valid=eq:true",
         ],
     )
@@ -384,18 +386,18 @@ def test_remote_data_query_command(
         [
             {
                 "field": "summary.global_quantities.ip.value",
-                "operator": "gt",
-                "value": -5,
+                "operator": "agt",
+                "value": "-5",
             },
             {
                 "field": "summary.global_quantities.ip.value",
-                "operator": "lt",
-                "value": 10,
+                "operator": "alt",
+                "value": "10",
             },
             {
                 "field": "summary.valid",
                 "operator": "eq",
-                "value": True,
+                "value": "true",
             },
         ],
         [
@@ -408,3 +410,14 @@ def test_remote_data_query_command(
         limit=25,
         page=1,
     )
+
+
+def test_remote_data_query_rejects_v1_2():
+    remote = mock.Mock(spec=RemoteAPI)
+    remote._api_version = "v1.2"
+
+    with pytest.raises(
+        RemoteError,
+        match=r"'query_simulation_data' is not supported.*version 'v1.2'",
+    ):
+        RemoteAPI.query_simulation_data(remote, [], [])

--- a/tests/cli/test_cli_remote_command.py
+++ b/tests/cli/test_cli_remote_command.py
@@ -374,8 +374,8 @@ def test_remote_data_query_command(
             "25",
             "--quantity",
             "ip=summary.global_quantities.ip.value",
-            "summary.global_quantities.ip.value=agt:-5",
-            "summary.global_quantities.ip.value=alt:10",
+            "summary.global_quantities.ip.value=gt:-5",
+            "summary.global_quantities.ip.value=lt:10",
             "summary.valid=eq:true",
         ],
     )
@@ -386,12 +386,12 @@ def test_remote_data_query_command(
         [
             {
                 "field": "summary.global_quantities.ip.value",
-                "operator": "agt",
+                "operator": "gt",
                 "value": "-5",
             },
             {
                 "field": "summary.global_quantities.ip.value",
-                "operator": "alt",
+                "operator": "lt",
                 "value": "10",
             },
             {

--- a/tests/cli/test_cli_remote_command.py
+++ b/tests/cli/test_cli_remote_command.py
@@ -335,3 +335,76 @@ def test_remote_query_command_with_verbose(
     assert args == (constraints, (), 100)
     assert kwargs == {}
     assert get_api_version.called
+
+
+@mock.patch("simdb.cli.remote_api.RemoteAPI.get_server_authentication")
+@mock.patch("simdb.cli.remote_api.RemoteAPI.get_endpoints")
+@mock.patch("simdb.cli.remote_api.RemoteAPI.get_api_version")
+@mock.patch("simdb.cli.remote_api.RemoteAPI.get_server_version")
+@mock.patch("simdb.cli.remote_api.RemoteAPI.query_simulation_data")
+def test_remote_data_query_command(
+    query_simulation_data,
+    get_server_version,
+    get_api_version,
+    get_endpoints,
+    get_server_authentication,
+):
+    get_endpoints.return_value = ["v1", "v1.1", "v1.1.1", "v1.2"]
+    get_api_version.return_value = "1.2"
+    get_server_version.return_value = "0.11"
+    get_server_authentication.return_value = "None"
+    query_simulation_data.return_value = {
+        "count": 1,
+        "page": 1,
+        "limit": 25,
+        "results": [{"alias": "inside-range", "quantities": {"ip": 2.0}}],
+    }
+
+    config_file = config_test_file()
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            f"--config-file={config_file}",
+            "remote",
+            "data-query",
+            "--limit",
+            "25",
+            "--quantity",
+            "ip=summary.global_quantities.ip.value",
+            "summary.global_quantities.ip.value=gt:-5",
+            "summary.global_quantities.ip.value=lt:10",
+            "summary.valid=eq:true",
+        ],
+    )
+
+    assert result.exception is None
+    assert '"inside-range"' in result.output
+    query_simulation_data.assert_called_once_with(
+        [
+            {
+                "field": "summary.global_quantities.ip.value",
+                "operator": "gt",
+                "value": -5,
+            },
+            {
+                "field": "summary.global_quantities.ip.value",
+                "operator": "lt",
+                "value": 10,
+            },
+            {
+                "field": "summary.valid",
+                "operator": "eq",
+                "value": True,
+            },
+        ],
+        [
+            {
+                "name": "ip",
+                "path": "summary.global_quantities.ip.value",
+                "source": "metadata",
+            }
+        ],
+        limit=25,
+        page=1,
+    )

--- a/tests/database/test_metadata_queries.py
+++ b/tests/database/test_metadata_queries.py
@@ -127,30 +127,6 @@ class TestQueryMeta:
         assert len(results) == 1
         assert results[0].find_meta("status") == ["passed"]
 
-    @pytest.mark.parametrize(
-        ("query_type", "value", "expected_alias"),
-        [
-            (QueryType.EQ, "true", "enabled"),
-            (QueryType.EQ, "false", "disabled"),
-            (QueryType.NE, "true", "disabled"),
-        ],
-    )
-    def test_query_meta_boolean_comparator(self, db, query_type, value, expected_alias):
-        db.insert_simulation(
-            create_simulation(alias="enabled", metadata={"flag": True})
-        )
-        db.insert_simulation(
-            create_simulation(alias="disabled", metadata={"flag": False})
-        )
-        db.insert_simulation(
-            create_simulation(alias="string-value", metadata={"flag": "true"})
-        )
-        db.session.commit()
-
-        results = db.query_meta([("flag", value, query_type)])
-
-        assert [result.alias for result in results] == [expected_alias]
-
     def test_query_meta_agt_comparator(self, db):
         sim1 = create_simulation(
             alias="sim1", metadata={"range": {"min": 1.0, "max": 5.0}}
@@ -251,54 +227,6 @@ class TestQueryMeta:
         assert len(results) == 2
         aliases = {r.alias for r in results}
         assert aliases == {"sim1", "sim3"}
-
-    def test_query_meta_all_values_inside_bounds(self, db):
-        sim1 = create_simulation(
-            alias="inside", metadata={"range": {"min": -4.0, "max": 9.0}}
-        )
-        sim2 = create_simulation(
-            alias="above", metadata={"range": {"min": 0.0, "max": 12.0}}
-        )
-        sim3 = create_simulation(
-            alias="below", metadata={"range": {"min": -8.0, "max": 2.0}}
-        )
-        db.insert_simulation(sim1)
-        db.insert_simulation(sim2)
-        db.insert_simulation(sim3)
-        db.session.commit()
-
-        results = db.query_meta(
-            [
-                ("range", "-5", QueryType.GT),
-                ("range", "10", QueryType.LT),
-            ]
-        )
-
-        assert [result.alias for result in results] == ["inside"]
-
-    @pytest.mark.parametrize(
-        ("query_type", "bound", "nonmatching_value"),
-        [
-            (QueryType.GT, "1", 0.0),
-            (QueryType.GE, "2", 1.0),
-            (QueryType.LT, "3", 4.0),
-            (QueryType.LE, "2", 3.0),
-        ],
-    )
-    def test_query_meta_scalar_bounds_remain_supported(
-        self, db, query_type, bound, nonmatching_value
-    ):
-        matching = create_simulation(alias="matching", metadata={"value": 2.0})
-        not_matching = create_simulation(
-            alias="not-matching", metadata={"value": nonmatching_value}
-        )
-        db.insert_simulation(matching)
-        db.insert_simulation(not_matching)
-        db.session.commit()
-
-        results = db.query_meta([("value", bound, query_type)])
-
-        assert [result.alias for result in results] == ["matching"]
 
 
 class TestListSimulationData:

--- a/tests/database/test_metadata_queries.py
+++ b/tests/database/test_metadata_queries.py
@@ -127,6 +127,30 @@ class TestQueryMeta:
         assert len(results) == 1
         assert results[0].find_meta("status") == ["passed"]
 
+    @pytest.mark.parametrize(
+        ("query_type", "value", "expected_alias"),
+        [
+            (QueryType.EQ, "true", "enabled"),
+            (QueryType.EQ, "false", "disabled"),
+            (QueryType.NE, "true", "disabled"),
+        ],
+    )
+    def test_query_meta_boolean_comparator(self, db, query_type, value, expected_alias):
+        db.insert_simulation(
+            create_simulation(alias="enabled", metadata={"flag": True})
+        )
+        db.insert_simulation(
+            create_simulation(alias="disabled", metadata={"flag": False})
+        )
+        db.insert_simulation(
+            create_simulation(alias="string-value", metadata={"flag": "true"})
+        )
+        db.session.commit()
+
+        results = db.query_meta([("flag", value, query_type)])
+
+        assert [result.alias for result in results] == [expected_alias]
+
     def test_query_meta_agt_comparator(self, db):
         sim1 = create_simulation(
             alias="sim1", metadata={"range": {"min": 1.0, "max": 5.0}}
@@ -227,6 +251,54 @@ class TestQueryMeta:
         assert len(results) == 2
         aliases = {r.alias for r in results}
         assert aliases == {"sim1", "sim3"}
+
+    def test_query_meta_all_values_inside_bounds(self, db):
+        sim1 = create_simulation(
+            alias="inside", metadata={"range": {"min": -4.0, "max": 9.0}}
+        )
+        sim2 = create_simulation(
+            alias="above", metadata={"range": {"min": 0.0, "max": 12.0}}
+        )
+        sim3 = create_simulation(
+            alias="below", metadata={"range": {"min": -8.0, "max": 2.0}}
+        )
+        db.insert_simulation(sim1)
+        db.insert_simulation(sim2)
+        db.insert_simulation(sim3)
+        db.session.commit()
+
+        results = db.query_meta(
+            [
+                ("range", "-5", QueryType.GT),
+                ("range", "10", QueryType.LT),
+            ]
+        )
+
+        assert [result.alias for result in results] == ["inside"]
+
+    @pytest.mark.parametrize(
+        ("query_type", "bound", "nonmatching_value"),
+        [
+            (QueryType.GT, "1", 0.0),
+            (QueryType.GE, "2", 1.0),
+            (QueryType.LT, "3", 4.0),
+            (QueryType.LE, "2", 3.0),
+        ],
+    )
+    def test_query_meta_scalar_bounds_remain_supported(
+        self, db, query_type, bound, nonmatching_value
+    ):
+        matching = create_simulation(alias="matching", metadata={"value": 2.0})
+        not_matching = create_simulation(
+            alias="not-matching", metadata={"value": nonmatching_value}
+        )
+        db.insert_simulation(matching)
+        db.insert_simulation(not_matching)
+        db.session.commit()
+
+        results = db.query_meta([("value", bound, query_type)])
+
+        assert [result.alias for result in results] == ["matching"]
 
 
 class TestListSimulationData:

--- a/tests/database/test_metadata_queries.py
+++ b/tests/database/test_metadata_queries.py
@@ -320,3 +320,18 @@ class TestQueryMetaData:
         assert count == 1
         assert len(results) == 1
         assert results[0]["metadata"] == [{"element": "type", "value": "A"}]
+
+    def test_query_meta_data_with_range_bounds(self, db):
+        db.insert_simulation(
+            create_simulation(
+                alias="inside",
+                metadata={"range": {"min": -4.0, "max": 9.0}},
+            )
+        )
+        db.session.commit()
+        constraints = [("range", "-5", QueryType.GT)]
+
+        count, results = db.query_meta_data(constraints, [])
+
+        assert count == 1
+        assert results[0]["alias"] == "inside"


### PR DESCRIPTION
```bash
 curl -sS -X POST http://localhost:5104/v1.2/simulations/data/query -H 'Content-Type: application/json' -d '{"filters":[{"field":"summary.global_quantities.ip.value","operator":"gt","value":-5},{"field":"summary.global_quantities.ip.value","operator":"lt","value":10}],"quantities":[{"name":"ip","path":"summary.global_quantities.ip.value"},{"name":"q95","path":"summary.global_quantities.q_95.value"}]}' | jq
{
  "count": 1,
  "page": 1,
  "limit": 100,
  "results": [
    {
      "uuid": {
        "_type": "uuid.UUID",
        "hex": "10000000000000000000000000000001"
      },
      "alias": "inside-range",
      "datetime": "2026-07-23T16:13:27.011355",
      "quantities": {
        "ip": {
          "source": "metadata",
          "path": "summary.global_quantities.ip.value",
          "value": {
            "min": -4.0,
            "max": 9.0
          }
        },
        "q95": {
          "source": "metadata",
          "path": "summary.global_quantities.q_95.value",
          "value": 3.1
        }
      },
      "missing": [],
      "errors": {}
    }
  ]
}
```

SimDB CLI test
```bash
$ simdb remote pr-109 test
Remote is valid (remote API version: 1.3)
$ simdb remote pr-109 data-query --quantity 'ip=summary.global_quantities.ip.value' --quantity 'q95=summary.global_quantities.q_95.value' 'summary.global_quantities.ip.value=gt:-5'
{
  "count": 2,
  "page": 1,
  "limit": 100,
  "results": [
    {
      "uuid": {
        "_type": "uuid.UUID",
        "hex": "10000000000000000000000000000001"
      },
      "alias": "inside-range",
      "datetime": "2026-07-23T16:13:27.011355",
      "quantities": {
        "ip": {
          "source": "metadata",
          "path": "summary.global_quantities.ip.value",
          "value": {
            "min": -4.0,
            "max": 9.0
          }
        },
        "q95": {
          "source": "metadata",
          "path": "summary.global_quantities.q_95.value",
          "value": 3.1
        }
      },
      "missing": [],
      "errors": {}
    },
    {
      "uuid": {
        "_type": "uuid.UUID",
        "hex": "10000000000000000000000000000002"
      },
      "alias": "above-range",
      "datetime": "2026-07-23T16:13:27.011355",
      "quantities": {
        "ip": {
          "source": "metadata",
          "path": "summary.global_quantities.ip.value",
          "value": {
            "min": 0.0,
            "max": 12.0
          }
        },
        "q95": {
          "source": "metadata",
          "path": "summary.global_quantities.q_95.value",
          "value": 4.2
        }
      },
      "missing": [],
      "errors": {}
    }
  ]
}
```