### PR TITLE
Fix/server version endpoint

### DIFF
--- a/src/simdb/cli/remote_api.py
+++ b/src/simdb/cli/remote_api.py
@@ -342,7 +342,7 @@ class RemoteAPI:
 
         self._api_version = selected_version
         self._api_url += f"{selected_version}/"
-        self.version = Version.coerce(self.get_api_version())
+        self.version = Version.coerce(selected_version.lstrip("v"))
         self.server_version = Version.coerce(self.get_server_version())
 
     def _load_cookies(
@@ -460,6 +460,32 @@ class RemoteAPI:
                 stream=stream,
             )
 
+        check_return(res)
+        return res
+
+    def get_root(
+        self,
+        headers: Optional[Dict] = None,
+        stream: bool = False,
+    ) -> "requests.Response":
+        """
+        Perform an HTTP GET request to the server root endpoint.
+
+        @param headers: additional headers to send with the request.
+        @param stream: True to enable streaming.
+        @return:
+        """
+
+        headers = headers or {}
+        headers["Accept-encoding"] = "gzip"
+        headers["User-Agent"] = "it_script_basic"
+
+        res = requests.get(
+            self._url,
+            headers=headers,
+            cookies=self._cookies,
+            stream=stream,
+        )
         check_return(res)
         return res
 
@@ -651,7 +677,7 @@ class RemoteAPI:
     @versioned_method("v1.2", "v1.3")
     @try_request
     def get_server_version(self) -> str:
-        res = self.get("", authenticate=False)
+        res = self.get_root()
         data = res.json()
         return data["server_version"]
 

--- a/src/simdb/remote/apis/__init__.py
+++ b/src/simdb/remote/apis/__init__.py
@@ -7,7 +7,6 @@ import jwt
 from flask import Blueprint, Response, jsonify, request
 from flask_restx import Resource
 
-from simdb import __version__
 from simdb.database import Database
 from simdb.remote.core.auth import AuthenticationError, User, requires_auth
 from simdb.remote.core.typing import current_app
@@ -82,7 +81,6 @@ def register(api, version, namespaces):
                 {
                     "api": "simdb",
                     "api_version": api.version,
-                    "server_version": __version__,
                     "endpoints": [
                         request.url + "simulations",
                         request.url + "files",

--- a/src/simdb/remote/app.py
+++ b/src/simdb/remote/app.py
@@ -6,6 +6,7 @@ from flask import Flask, jsonify, request
 from flask_compress import Compress
 from flask_cors import CORS
 
+from simdb import __version__
 from simdb.config import Config
 from simdb.database.database import check_migrations, run_migrations
 
@@ -57,6 +58,7 @@ def create_app(
                 "endpoints": endpoints,
                 "authentication": authenticators[0].Name,
                 "authenticators": [auth.Name for auth in authenticators],
+                "server_version": __version__,
             }
         )
 


### PR DESCRIPTION
This PR help move the server_version metadata to the server homepage, and fixed the `get_server_version` function to request from the server homepage rather than the api version index page. 