### PR TITLE
Feature/validation extension

### DIFF
--- a/src/simdb/cli/commands/simulation.py
+++ b/src/simdb/cli/commands/simulation.py
@@ -248,7 +248,7 @@ def simulation_push(
     schemas = api.get_validation_schemas()
     try:
         for schema in schemas:
-            Validator(schema).validate(simulation)
+            Validator(schema, config).validate(simulation)
     except ValidationError as err:
         raise click.ClickException(f"Simulation does not validate: {err}") from err
 
@@ -471,7 +471,7 @@ def simulation_validate(
 
     click.echo("validating metadata ... ", nl=False)
     for schema in schemas:
-        Validator(schema).validate(simulation)
+        Validator(schema, config).validate(simulation)
 
     ids_list = []
     for file in chain(simulation.inputs, simulation.outputs):

--- a/src/simdb/cli/remote_api.py
+++ b/src/simdb/cli/remote_api.py
@@ -42,7 +42,7 @@ from simdb.remote import CLIENT_API_VERSIONS, APIConstants
 from .manifest import DataType
 
 if TYPE_CHECKING:
-    from simdb.database.models import File, Simulation, Watcher
+    from simdb.database.models import File, Watcher
 
 if TYPE_CHECKING or "sphinx" in sys.modules:
     # Only importing these for type checking and documentation generation in order to

--- a/src/simdb/database/models/simulation.py
+++ b/src/simdb/database/models/simulation.py
@@ -163,7 +163,7 @@ class Simulation(Base):
         Returns a list of MetaDataWrapper objects from the JSON metadata.
         """
         meta_dict = self._get_metadata_dict()
-        return [MetaDataWrapper(k, v) for k, v in meta_dict.items()]
+        return list(itertools.starmap(MetaDataWrapper, meta_dict.items()))
 
     def _get_metadata_dict(self) -> Dict[str, Any]:
         if self._metadata is None:

--- a/src/simdb/remote/apis/v1/simulations.py
+++ b/src/simdb/remote/apis/v1/simulations.py
@@ -52,7 +52,7 @@ Note: please don't reply to this email, replies to this address are not monitore
 def _validate(simulation, user) -> Dict:
     schema = Validator.validation_schema()
     try:
-        Validator(schema).validate(simulation)
+        Validator(schema, current_app.simdb_config).validate(simulation)
         _update_simulation_status(simulation, models_sim.Simulation.Status.PASSED, user)
         return {
             "passed": True,

--- a/src/simdb/remote/apis/v1_1/simulations.py
+++ b/src/simdb/remote/apis/v1_1/simulations.py
@@ -53,7 +53,7 @@ def _validate(simulation, user) -> Dict:
     schemas = Validator.validation_schemas(current_app.simdb_config, simulation)
     try:
         for schema in schemas:
-            Validator(schema).validate(simulation)
+            Validator(schema, current_app.simdb_config).validate(simulation)
             _update_simulation_status(
                 simulation, models_sim.Simulation.Status.PASSED, user
             )

--- a/src/simdb/remote/apis/v1_2/simulations.py
+++ b/src/simdb/remote/apis/v1_2/simulations.py
@@ -82,7 +82,7 @@ def _validate(simulation, user) -> ValidationResult:
     schemas = Validator.validation_schemas(current_app.simdb_config, simulation)
     try:
         for schema in schemas:
-            Validator(schema).validate(simulation)
+            Validator(schema, current_app.simdb_config).validate(simulation)
             _update_simulation_status(
                 simulation, models_sim.Simulation.Status.PASSED, user
             )

--- a/src/simdb/validation/file/ids_validator.py
+++ b/src/simdb/validation/file/ids_validator.py
@@ -43,7 +43,7 @@ class IdsValidator(FileValidatorBase):
             .split(",")
         ]
 
-        ### Define logic for rule_filter
+        # Define logic for rule_filter
         list_of_filter_names = (
             arguments.get("rule_filter_name", "").strip('"').split(",")
         )

--- a/src/simdb/validation/validator.py
+++ b/src/simdb/validation/validator.py
@@ -209,12 +209,14 @@ class Validator:
 
         if not isinstance(module_path, str):
             raise TypeError(
-                f"Expected 'custom_validator config value' to be a string, got {type(module_path).__name__}"
+                "Expected 'custom_validator config value' to be a string, "
+                f"got {type(module_path).__name__}"
             )
 
         if "." not in module_path:
             raise ValueError(
-                f"Invalid validator path '{module_path}'. Expected format: 'package.module.ClassName'"
+                f"Invalid validator path '{module_path}'."
+                "Expected format: 'package.module.ClassName'"
             )
 
         module_name, class_name = module_path.rsplit(".", 1)
@@ -230,7 +232,8 @@ class Validator:
             validation_cls = getattr(module, class_name)
         except AttributeError as e:
             raise AttributeError(
-                f"Module '{module_name}' does not have class or attribute '{class_name}'"
+                f"Module '{module_name}' does not have class"
+                f"or attribute '{class_name}'"
             ) from e
         return validation_cls
 

--- a/src/simdb/validation/validator.py
+++ b/src/simdb/validation/validator.py
@@ -232,8 +232,7 @@ class Validator:
             validation_cls = getattr(module, class_name)
         except AttributeError as e:
             raise AttributeError(
-                f"Module '{module_name}' does not have class"
-                f"or attribute '{class_name}'"
+                f"Module '{module_name}' does not have classor attribute '{class_name}'"
             ) from e
         return validation_cls
 

--- a/src/simdb/validation/validator.py
+++ b/src/simdb/validation/validator.py
@@ -1,5 +1,6 @@
 import re
 import warnings
+from importlib import import_module
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union, cast
 
@@ -201,7 +202,6 @@ class Validator:
         return schemas
 
     def _custom_validation_ext(self, config: Config):
-        from importlib import import_module
 
         module_path = config.get_option("validation.custom_validator", default=None)
         if module_path is None:
@@ -223,17 +223,17 @@ class Validator:
 
         try:
             module = import_module(module_name)
-        except ModuleNotFoundError as e:
+        except ModuleNotFoundError as err:
             raise ImportError(
-                f"Unable to import module '{module_name}': {e}. "
+                f"Unable to import module '{module_name}': {err}. "
                 "Please ensure the necessary validation package is installed"
-            ) from e
+            ) from err
         try:
             validation_cls = getattr(module, class_name)
-        except AttributeError as e:
+        except AttributeError as err:
             raise AttributeError(
                 f"Module '{module_name}' does not have classor attribute '{class_name}'"
-            ) from e
+            ) from err
         return validation_cls
 
     def __init__(self, schema: Dict, config: Config):
@@ -241,8 +241,8 @@ class Validator:
             validation_cls = self._custom_validation_ext(config)
             self._validator = validation_cls(schema)
             self._validator.allow_unknown = True
-        except cerberus.SchemaError:
-            raise LoadError("Failed to parse validation schema")
+        except cerberus.SchemaError as err:
+            raise LoadError("Failed to parse validation schema") from err
 
     def validate(self, sim: Simulation) -> None:
         # convert sim to dictionary

--- a/src/simdb/validation/validator.py
+++ b/src/simdb/validation/validator.py
@@ -200,12 +200,47 @@ class Validator:
 
         return schemas
 
-    def __init__(self, schema: Dict):
+    def _custom_validation_ext(self, config: Config):
+        from importlib import import_module
+
+        module_path = config.get_option("validation.custom_validator", default=None)
+        if module_path is None:
+            return CustomValidator
+
+        if not isinstance(module_path, str):
+            raise TypeError(
+                f"Expected 'custom_validator config value' to be a string, got {type(module_path).__name__}"
+            )
+
+        if "." not in module_path:
+            raise ValueError(
+                f"Invalid validator path '{module_path}'. Expected format: 'package.module.ClassName'"
+            )
+
+        module_name, class_name = module_path.rsplit(".", 1)
+
         try:
-            self._validator = CustomValidator(schema)
+            module = import_module(module_name)
+        except ModuleNotFoundError as e:
+            raise ImportError(
+                f"Unable to import module '{module_name}': {e}. "
+                "Please ensure the necessary validation package is installed"
+            ) from e
+        try:
+            validation_cls = getattr(module, class_name)
+        except AttributeError as e:
+            raise AttributeError(
+                f"Module '{module_name}' does not have class or attribute '{class_name}'"
+            ) from e
+        return validation_cls
+
+    def __init__(self, schema: Dict, config: Config):
+        try:
+            validation_cls = self._custom_validation_ext(config)
+            self._validator = validation_cls(schema)
             self._validator.allow_unknown = True
-        except cerberus.SchemaError as err:
-            raise LoadError("Failed to parse validation schema") from err
+        except cerberus.SchemaError:
+            raise LoadError("Failed to parse validation schema")
 
     def validate(self, sim: Simulation) -> None:
         # convert sim to dictionary

--- a/tests/remote/api/conftest.py
+++ b/tests/remote/api/conftest.py
@@ -1,5 +1,4 @@
 import base64
-import importlib
 import importlib.util
 import os
 import shutil

--- a/tests/remote/test_authentication.py
+++ b/tests/remote/test_authentication.py
@@ -1,4 +1,3 @@
-import importlib
 import importlib.util
 from typing import TYPE_CHECKING, ClassVar, cast
 from unittest import mock


### PR DESCRIPTION
Summary

This PR introduces support for loading an extended custom validator class from the server configuration. This allows users to extend SimDB's validation framework while remaining compatible with upstream releases, without needing to modify SimDB directly.

With this feature, users can install their own validation package into the application's virtual environment and specify the validator class to use in the server configuration.

Example configuration:

`validation:
  custom_validator: myvalidator.validators.MyValidator`

How it works

At startup, SimDB will:

Read the configured validator class path.
Dynamically import the specified module.
Load the configured validator class.
Verify that it inherits from CustomValidator.
Use the configured validator class throughout the validation pipeline instead of the default CustomValidator.
If no custom validator is configured, SimDB continues to use the built-in CustomValidator, preserving the existing behaviour.


Benefits

Enables project-specific validation rules without modifying SimDB.
Makes the validation framework extensible while remaining compatible with upstream releases.
Maintains backward compatibility when no custom validator is configured.
Provides a clean extension point for custom validation implementations.

Example use case

A project can create its own package containing a validator implementation:

`from simdb.validation.validator import CustomValidator
  class MyValidator(CustomValidator):`
    ...

After installing the package into the same virtual environment as SimDB, the project only needs to configure:

`[validation]:
  custom_validator: myvalidator.validators.MyValidator`

No changes to the SimDB source code are required.